### PR TITLE
Убрал создание комментария при генерации CSS технологии

### DIFF
--- a/lib/techs/css.js
+++ b/lib/techs/css.js
@@ -17,7 +17,6 @@ exports.Tech = INHERIT(Tech, {
         return Template.process([
             '{{bemSelector}}',
             '{',
-            '    /* ... */',
             '}'],
             vars);
 


### PR DESCRIPTION
Убрал создание комментария при генерации CSS технологии, постоянно его приходится удалять -- лишние телодвижения.

Было:
b-test.css

``` .b-test
{
    /* ... */
}
```

Стало:
b-test.css

``` .b-test
{
}
```
