### PR TITLE
fixed README.md, prevent rewriting .zshrc / .bashrc with bem completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@
 
 Если вы не используете `bash-completion`, можете добавить вывод `bem completion` себе в `.bashrc`:
 
-    bem completion > ~/.bashrc
+    bem completion >> ~/.bashrc
 
 #### zsh
 
 Если вы используете `zsh`, можете добавить вывод `bem completion` себе в `.zshrc`, после чего перелогиньтесь:
 
-    bem completion > ~/.zshrc
+    bem completion >> ~/.zshrc
 
 ### Консольные команды
 #### bem create


### PR DESCRIPTION
Fixed documentation. 

Old commands : 

bem completion > ~/.bashrc
bem completion > ~/.zshrc

It could be sad to rewrite entire .bashrc or .zshrc file with only bem completion

Fixed commands:

bem completion > ~/.bashrc
bem completion > ~/.zshrc
