### PR TITLE
Separate method for calculation build results destination path

### DIFF
--- a/lib/tech.js
+++ b/lib/tech.js
@@ -272,6 +272,17 @@ var UTIL = require('util'),
         },
 
         /**
+         * Returns path for build results
+         * @protected
+         * @param {String} prefix
+         * @param {String} suffix
+         * @returns {String}
+         */
+        getBuildStorePath: function(prefix, suffix) {
+            return this.getPath(prefix, suffix);
+        },
+
+        /**
          * Stores result of build for specified suffix
          * @protected
          * @param {String} path    path of object to store
@@ -293,7 +304,8 @@ var UTIL = require('util'),
             return Q.when(res, function(res) {
                 var done;
                 _this.getSuffixes().forEach(function(suffix) {
-                    done = Q.wait(done, _this.storeBuildResult(_this.getPath(prefix, suffix), suffix, res[suffix]));
+                    done = Q.wait(done,
+                        _this.storeBuildResult(_this.getBuildStorePath(prefix, suffix), suffix, res[suffix]));
                 });
                 return done;
             });


### PR DESCRIPTION
Вынес вычисление пути до результатов `getBuildResult()` в отдельный protected-метод
