### PR TITLE
Refactor nodes

### DIFF
--- a/lib/default-arch.js
+++ b/lib/default-arch.js
@@ -77,11 +77,10 @@ exports.Arch = INHERIT({
 
             var lib = libs[l],
                 libNodeClass = U.toUpperCaseFirst(lib.type) + 'LibraryNode',
-                libNode = new (registry.getNodeClass(libNodeClass))(
-                    l,
-                    lib.url,
-                    lib.paths,
-                    lib.treeish);
+                libNode = new (registry.getNodeClass(libNodeClass))(U.extend({}, lib, {
+                        root: this.root,
+                        target: l
+                    }));
 
             this.arch.setNode(libNode, parent);
             return libNode.getId();
@@ -111,15 +110,19 @@ exports.Arch = INHERIT({
     createLevelsNodes: function(mask, nodeClass, parent, children) {
         var _this = this;
 
-        return this.getLevels(mask).then(function(levels) {
-            return levels.map(function(level) {
-                var node = new nodeClass(_this.absolutePath(level));
+        return this.getLevels(mask)
+            .then(function(levels) {
+                return levels.map(function(level) {
+                    var node = new nodeClass({
+                        root: _this.root,
+                        level: level
+                    });
 
-                _this.arch.setNode(node, parent, children);
+                    _this.arch.setNode(node, parent, children);
 
-                return node.getId();
+                    return node.getId();
+                });
             });
-        });
     },
 
     getLevels: function(mask) {
@@ -127,10 +130,6 @@ exports.Arch = INHERIT({
             .invoke('filter', function(dir) {
                 return dir.match(mask);
             });
-    },
-
-    absolutePath: function(path) {
-        return PATH.join(this.root, path);
     }
 
 });

--- a/lib/nodes/block.js
+++ b/lib/nodes/block.js
@@ -1,42 +1,54 @@
 var INHERIT = require('inherit'),
     PATH = require('path'),
-    UTIL = require('../util'),
+    U = require('../util'),
     createLevel = require('../index').createLevel,
     MagicNode = require('./magic').MagicNode;
 
 var BlockNode = exports.BlockNode = INHERIT(MagicNode, {
 
-    __constructor: function(level, blockNameOrItem) {
-        this.level = typeof level == 'string'? createLevel(level) : level;
+    __constructor: function(o) {
 
-        this.item = (typeof blockNameOrItem === 'string')? createItem(blockNameOrItem) : blockNameOrItem;
+        this.level = typeof o.level === 'string'? createLevel(o.level) : o.level;
+        this.item = o.item || o;
+        this.__base(U.extend({ path: PATH.dirname(this.getNodePrefix(o)) }, o));
 
-        this.__base(this.getNodePrefix());
     },
 
-    make: function(ctx) {},
+    make: function() {},
 
-    getNodePrefix: function() {
+    getNodePrefix: function(o) {
+
         if (!this._nodePrefix) {
-            this._nodePrefix = this.__self._createId(this.level, this.item);
+            this._nodePrefix = this.__self.createNodePrefix(o || {
+                root: this.root,
+                level: this.level,
+                item: this.item
+            });
         }
         return this._nodePrefix;
+
     }
 
 }, {
 
-    createId: function(level, blockNameOrItem) {
-        return this.__base(this._createId(level, blockNameOrItem));
+    createId: function(o) {
+
+        o.path = o.path || this.createPath(o);
+        return this.__base(o);
+
     },
 
-    _createId: function(level, blockNameOrItem) {
-        return PATH.dirname(UTIL.getNodePrefix(
-            (typeof level == 'string')? createLevel(level) : level,
-            (typeof blockNameOrItem === 'string')? createItem(blockNameOrItem) : blockNameOrItem));
+    createPath: function(o) {
+        return PATH.dirname(this.createNodePrefix(o));
+    },
+
+    createNodePrefix: function(o) {
+
+        var level = typeof o.level === 'string'? createLevel(o.level) : o.level;
+        return PATH.join(
+            PATH.relative(o.root, level.dir),
+            level.getRelByObj(o.item));
+
     }
 
 });
-
-function createItem(blockName) {
-    return { block: blockName };
-}

--- a/lib/nodes/block.js
+++ b/lib/nodes/block.js
@@ -32,10 +32,7 @@ var BlockNode = exports.BlockNode = INHERIT(MagicNode, {
 }, {
 
     createId: function(o) {
-
-        o.path = o.path || this.createPath(o);
-        return this.__base(o);
-
+        return this.__base(U.extend({ path: o.path || this.createPath(o) }, o));
     },
 
     createPath: function(o) {

--- a/lib/nodes/block.js
+++ b/lib/nodes/block.js
@@ -8,18 +8,21 @@ var BlockNode = exports.BlockNode = INHERIT(MagicNode, {
 
     __constructor: function(o) {
 
-        this.level = typeof o.level === 'string'? createLevel(o.level) : o.level;
+        this.level = typeof o.level === 'string'?
+            createLevel(PATH.resolve(o.root, o.level)) :
+            o.level;
         this.item = o.item || o;
-        this.__base(U.extend({ path: PATH.dirname(this.getNodePrefix(o)) }, o));
+
+        this.__base(U.extend({ path: this.__self.createPath(o) }, o));
 
     },
 
     make: function() {},
 
-    getNodePrefix: function(o) {
+    getNodePrefix: function() {
 
         if (!this._nodePrefix) {
-            this._nodePrefix = this.__self.createNodePrefix(o || {
+            this._nodePrefix = this.__self.createNodePrefix({
                 root: this.root,
                 level: this.level,
                 item: this.item
@@ -32,7 +35,7 @@ var BlockNode = exports.BlockNode = INHERIT(MagicNode, {
 }, {
 
     createId: function(o) {
-        return this.__base(U.extend({ path: o.path || this.createPath(o) }, o));
+        return this.createPath(o) + '*';
     },
 
     createPath: function(o) {
@@ -41,10 +44,11 @@ var BlockNode = exports.BlockNode = INHERIT(MagicNode, {
 
     createNodePrefix: function(o) {
 
-        var level = typeof o.level === 'string'? createLevel(o.level) : o.level;
-        return PATH.join(
-            PATH.relative(o.root, level.dir),
-            level.getRelByObj(o.item));
+        var level = typeof o.level === 'string'?
+            createLevel(PATH.resolve(o.root, o.level)) :
+            o.level;
+
+        return PATH.relative(o.root, level.getByObj(o.item));
 
     }
 

--- a/lib/nodes/borschik.js
+++ b/lib/nodes/borschik.js
@@ -3,7 +3,7 @@ var INHERIT = require('inherit'),
     PATH = require('path'),
     CP = require('child_process'),
     LOGGER = require('../logger'),
-    createLevel = require('../level').createLevel,
+    U = require('../util'),
 
     GeneratedFileNode = require('./file').GeneratedFileNode,
 
@@ -11,23 +11,24 @@ var INHERIT = require('inherit'),
 
 exports.BorschikNode = INHERIT(GeneratedFileNode, {
 
-    __constructor: function(sourceNode, tech, forked) {
+    __constructor: function(o) {
 
-        this.tech = tech;
-        this.forked = forked;
+        this.tech = o.tech;
+        this.forked = o.forked;
 
-        this.input = typeof sourceNode === 'string'
-            ? sourceNode
-            : sourceNode.getId();
-        this.output = PATH.join(PATH.dirname(this.input), '_' + PATH.basename(this.input));
+        this.input = typeof o.sourceNode === 'string'
+            ? o.sourceNode
+            : o.sourceNode.getId();
 
-        this.__base(this.output);
+        this.__base(U.extend({ path: PATH.join(PATH.dirname(this.input), '_' + PATH.basename(this.input)) }, o));
+
     },
 
-    make: function(ctx) {
+    make: function() {
+
         var opts = {
-            input: PATH.join(ctx.root, this.input),
-            output: PATH.join(ctx.root, this.output),
+            input: PATH.join(this.root, this.input),
+            output: this.getPath(),
             tech: this.tech
         };
 
@@ -57,6 +58,7 @@ exports.BorschikNode = INHERIT(GeneratedFileNode, {
         worker.send(opts);
 
         return d.promise;
-    }
-});
 
+    }
+
+});

--- a/lib/nodes/build.js
+++ b/lib/nodes/build.js
@@ -9,48 +9,49 @@ var _ = require('underscore'),
     BEM = require('../coa').api,
     createLevel = require('../level').createLevel,
     Context = require('../context').Context,
+    U = require('../util'),
 
     FileNode = require('./file').FileNode,
     GeneratedFileNode = require('./file').GeneratedFileNode,
 
-    require = require('../util').requireWrapper(require);
+    wrappedRequire = U.requireWrapper(require);
 
 var BemBuildNode = exports.BemBuildNode = INHERIT(GeneratedFileNode, {
 
-    __constructor: function(bundlesLevel, levels, decl, techPath, techName, output, forked) {
-        this.bundlesLevel = bundlesLevel;
-        this.levelsPaths = levels;
-        this.levels = levels.map(function(l) {
-            return typeof l == 'string'? createLevel(l) : l;
-        });
-        this.declPath = decl;
-        this.techName = techName;
-        this.output = output;
-        this.forked = typeof forked === 'undefined'? true : !!forked;
+    __constructor: function(o) {
+
+        this.bundlesLevel = o.bundlesLevel;
+        this.levelsPaths = o.levels;
+        this.levels = o.levels.map(createLevel);
+        this.declPath = o.declPath;
+        this.techName = o.techName;
+        this.output = o.output;
+        this.forked = typeof o.forked === 'undefined'? true : !!o.forked;
 
         // NOTE: Every time we need new tech object so we use createTech().
         // If we use getTech(), we'll overwrite context of the same tech
         // object that is prone to collisions
-        this.tech = this.bundlesLevel.createTech(techName, techPath);
+        this.tech = this.bundlesLevel.createTech(o.techName, o.techPath);
         this.techPath = this.tech.getTechPath();
         this.tech.setContext(new Context(this.levels));
 
-        this.__base(this.tech.getPath(this.output));
+        this.__base(U.extend({ path: this.__self.createId(o) }, o));
+
     },
 
-    isValid: function(ctx) {
+    isValid: function() {
         var _this = this;
 
-        return Q.when(this.__base(ctx), function(valid){
+        return Q.when(this.__base(), function(valid){
             if (!valid) return false;
 
             var meta = _this.getMetaNode();
-            if (!ctx.arch.hasNode(meta)) return false;
+            if (!_this.ctx.arch.hasNode(meta)) return false;
 
             return Q.all([
-                    _this.readMeta(ctx),
-                    _this.lastModified(ctx),
-                    meta.lastModified(ctx)
+                    _this.readMeta(),
+                    _this.lastModified(),
+                    meta.lastModified()
                 ])
                 .spread(function(meta, nodeLastModified, metaLastModified) {
 
@@ -63,7 +64,7 @@ var BemBuildNode = exports.BemBuildNode = INHERIT(GeneratedFileNode, {
                     var valid = true;
                     return Q.all(meta.map(function(m) {
 
-                        return QFS.lastModified(PATH.resolve(ctx.root, m))
+                        return QFS.lastModified(PATH.resolve(_this.root, m))
                             .then(function(d) {
                                 if (d > nodeLastModified) valid = false;
                             })
@@ -80,12 +81,12 @@ var BemBuildNode = exports.BemBuildNode = INHERIT(GeneratedFileNode, {
         });
     },
 
-    make: function(ctx) {
+    make: function() {
         var opts = {
             level: this.levelsPaths,
-            declaration: PATH.resolve(ctx.root, this.declPath),
+            declaration: PATH.resolve(this.root, this.declPath),
             tech: this.techPath,
-            outputName: PATH.resolve(ctx.root, this.output)
+            outputName: PATH.resolve(this.root, this.output)
         };
 
         this.log('bem.build(forked=%j, %s)', this.forked, JSON.stringify(opts, null, 4));
@@ -118,15 +119,15 @@ var BemBuildNode = exports.BemBuildNode = INHERIT(GeneratedFileNode, {
         return d.promise;
     },
 
-    readMeta: function(ctx) {
-        return this._readMeta(ctx, this.getMetaNode().getPath());
+    readMeta: function() {
+        return this._readMeta(this.getMetaNode().getPath());
     },
 
-    _readMeta: function(ctx, path) {
+    _readMeta: function(path) {
 
-        path = PATH.resolve(ctx.root, path);
+        path = PATH.resolve(this.root, path);
         var _this = this,
-            relativize = getPathRelativizer(ctx.root);
+            relativize = getPathRelativizer(this.root);
 
         return QFS.read(path)
             .then(function(c) {
@@ -143,17 +144,25 @@ var BemBuildNode = exports.BemBuildNode = INHERIT(GeneratedFileNode, {
     },
 
     getMetaNode: function() {
-        return (this.metaNode || (this.metaNode = new BemBuildMetaNode(
-            this.bundlesLevel,
-            this.levelsPaths,
-            this.declPath,
-            this.techPath,
-            this.techName,
-            this.output,
-            this.forked)));
+
+        var node = this.metaNode || (this.metaNode = new BemBuildMetaNode({
+            root: this.root,
+            bundlesLevel: this.bundlesLevel,
+            levels: this.levelsPaths,
+            declPath: this.declPath,
+            techPath: this.techPath,
+            techName: this.techName,
+            output: this.output,
+            forked: this.forked
+        }));
+
+        node.buildNode = this;
+
+        return node;
+
     },
 
-    getCreateDependencies: function(ctx) {
+    getCreateDependencies: function() {
 
         var deps = this.tech.getDependencies().map(function(d) {
             return this.bundlesLevel.getPath(this.output, d);
@@ -164,31 +173,35 @@ var BemBuildNode = exports.BemBuildNode = INHERIT(GeneratedFileNode, {
 
     }
 
+}, {
+
+    createId: function(o) {
+
+        return o.bundlesLevel
+            .createTech(o.techName, o.techPath)
+            .getPath(o.output);
+
+    }
+
 });
 
 var BemBuildMetaNode = exports.BemBuildMetaNode = INHERIT(BemBuildNode, {
 
-    getId: function() {
-        return this.getPath();
-    },
+    isValid: function() {
 
-    getPath: function() {
-        return this.path + '.meta.js';
-    },
-
-    isValid: function(ctx) {
+        var ctx = this.ctx;
 
         // expired in case of clean or other methods
         if (ctx.method && ctx.method != 'make') return false;
 
         // TODO: use decl tech readContent()
-        var decl = require(PATH.resolve(ctx.root, this.declPath), true),
+        var decl = wrappedRequire(PATH.resolve(this.root, this.declPath), true),
             tech = this.tech,
-            relativize = getPathRelativizer(ctx.root),
+            relativize = getPathRelativizer(this.root),
             prefixes = tech.getBuildPrefixes(tech.transformBuildDecl(decl), this.levels),
             filteredPaths = tech.filterPrefixes(prefixes, tech.getSuffixes())
                 .invoke('map', relativize),
-            savedPaths = this.readMeta(ctx);
+            savedPaths = this.readMeta();
 
         ctx.prefixes = prefixes;
         ctx.filteredPaths = filteredPaths;
@@ -214,11 +227,12 @@ var BemBuildMetaNode = exports.BemBuildMetaNode = INHERIT(BemBuildNode, {
             });
     },
 
-    make: function(ctx) {
+    make: function() {
         var _this = this,
+            ctx = this.ctx,
             tech = this.tech,
             arch = ctx.arch,
-            relativize = getPathRelativizer(ctx.root),
+            relativize = getPathRelativizer(this.root),
             allPaths = ctx.prefixes.then(function(prefixes) {
                 return tech.getPaths(prefixes).map(relativize);
             });
@@ -226,28 +240,29 @@ var BemBuildMetaNode = exports.BemBuildMetaNode = INHERIT(BemBuildNode, {
         return Q.all([allPaths, ctx.filteredPaths, ctx.savedPaths])
             .spread(function(allPaths, filteredPaths, savedPaths) {
 
-                return arch.withLock(_this.alterArch(ctx, allPaths, filteredPaths, savedPaths), _this)
+                return arch.withLock(_this.alterArch(allPaths, filteredPaths, savedPaths), _this)
                     .then(function() {
 
                         // write file list to .meta.js
-                        var relativize = getPathRelativizer(PATH.dirname(_this.getPath())),
+                        var relativize = getPathRelativizer(PATH.dirname(_this.path)),
                             paths = filteredPaths.map(function(f) {
                                 return relativize(f);
                             });
 
-                        return QFS.write(PATH.resolve(ctx.root, _this.getPath()), '(' + JSON.stringify(paths, null, 4) + ')');
+                        return QFS.write(_this.getPath(), '(' + JSON.stringify(paths, null, 4) + ')');
 
                     });
 
             });
     },
 
-    alterArch: function(ctx, allPaths, filteredPaths, savedPaths) {
+    alterArch: function(allPaths, filteredPaths, savedPaths) {
 
         return function() {
 
-            var arch = ctx.arch,
-                buildNodeId = this.id;
+            var ctx = this.ctx,
+                arch = ctx.arch,
+                buildNodeId = this.buildNode.getId();
 
             // find difference with array read from file and filteredPaths
             var obsolete = _.difference(savedPaths, filteredPaths);
@@ -262,17 +277,26 @@ var BemBuildMetaNode = exports.BemBuildMetaNode = INHERIT(BemBuildNode, {
 
             // create nodes for all existent paths to blocks files: FileNode(path)
             filteredPaths.forEach(function(p) {
-                arch.hasNode(p) || arch.addNode(new FileNode(p));
+                arch.hasNode(p) || arch.addNode(new FileNode({
+                    root: this.root,
+                    path: p
+                }));
                 // link created nodes to BemBuildNode corresponding to this node
                 ctx.plan.link(p, buildNodeId);
-            });
+            }, this);
 
         }
 
     },
 
-    readMeta: function(ctx) {
-        return this._readMeta(ctx, this.getPath());
+    readMeta: function() {
+        return this._readMeta(this.getPath());
+    }
+
+}, {
+
+    createId: function(o) {
+        return this.__base(o) + '.meta.js';
     }
 
 });

--- a/lib/nodes/build.js
+++ b/lib/nodes/build.js
@@ -162,7 +162,7 @@ var BemBuildNode = exports.BemBuildNode = INHERIT(GeneratedFileNode, {
 
     },
 
-    getCreateDependencies: function() {
+    getDependencies: function() {
 
         var deps = this.tech.getDependencies().map(function(d) {
             return this.bundlesLevel.getPath(this.output, d);
@@ -294,6 +294,10 @@ var BemBuildMetaNode = exports.BemBuildMetaNode = INHERIT(BemBuildNode, {
 
     readMeta: function() {
         return this._readMeta(this.getPath());
+    },
+
+    getDependencies: function() {
+        return [this.declPath];
     }
 
 }, {

--- a/lib/nodes/bundle.js
+++ b/lib/nodes/bundle.js
@@ -129,8 +129,8 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
             if (!this.ctx.arch.hasNode(d)) {
                 LOGGER.fverbose('dependency %s is required to build %s but does not exist, checking if target already built', d, node.getId());
 
-                if (!PATH.existsSync(PATH.resolve(this.ctx.root, node.getId()))) {
-                    LOGGER.fwarn('%s will not be built because dependency file %s does not exist', node.getId(), d);
+                if (!PATH.existsSync(node.getPath())) {
+                    LOGGER.fwarn('%s will not be built because dependency file %s does not exist', node.path, d);
                     return null;
                 }
 
@@ -185,7 +185,7 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
         var arch = this.ctx.arch,
             filePath = this.getBundlePath(tech);
 
-        if (!PATH.existsSync(PATH.resolve(this.ctx.root, filePath))) return;
+        if (!PATH.existsSync(PATH.resolve(this.root, filePath))) return;
 
         var node = new FileNode({
             root: this.root,

--- a/lib/nodes/bundle.js
+++ b/lib/nodes/bundle.js
@@ -172,14 +172,18 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
                 techName: techName,
                 output: this.getNodePrefix(),
                 forked: forked
-            });
+            }),
+            metaNode = buildNode.getMetaNode();
 
-        arch.setNode(buildNode);
+        // Set bem build node to arch
+        arch.setNode(buildNode)
+            .addChildren(buildNode, buildNode.getDependencies());
 
         bundleNode && arch.addParents(buildNode, bundleNode);
         magicNode && arch.addChildren(buildNode, magicNode);
 
-        arch.setNode(buildNode.getMetaNode(), buildNode, declPath);
+        // Set bem build meta node to arch
+        arch.setNode(metaNode, buildNode, metaNode.getDependencies());
 
         return buildNode;
 

--- a/lib/nodes/bundle.js
+++ b/lib/nodes/bundle.js
@@ -41,10 +41,10 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
             // generate targets for page files
             var techTargets = {};
             this.getTechs().map(function(tech) {
-                var techNode = this.createNode(tech, bundleNode, this);
+                var techNode = this.createTechNode(tech, bundleNode, this);
                 if (techNode) {
                     techTargets[tech] = techNode.getId();
-                    this.createOptimizerNode(tech, bundleNode, techNode);
+                    this.createOptimizerNode(tech, techNode, bundleNode);
                 }
             }, this);
 
@@ -59,22 +59,26 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
         return Q.resolve(0);
     },
 
-    createNode: function(tech, bundleNode, magicNode) {
+    createTechNode: function(tech, bundleNode, magicNode) {
+
         var f = 'create-' + tech + '-node';
+        f = typeof this[f] === 'function'? f : 'createDefaultTechNode';
 
-        LOGGER.fdebug('using %s() to create node for tech %s', this[f]?f:'createDefaultNode', tech);
+        LOGGER.fdebug('Using %s() to create node for tech %s', f, tech);
 
-        return (this[f] ||
-            this.createDefaultNode).call(this, tech, bundleNode, magicNode);
+        return this[f].apply(this, arguments);
+
     },
 
-    createOptimizerNode: function(tech, bundleNode, sourceNode) {
+    createOptimizerNode: function(tech, sourceNode, bundleNode) {
+
         var f = 'create-' + tech + '-optimizer-node';
+        f = typeof this[f] === 'function'? f : 'createDefaultOptimizerNode';
 
-        LOGGER.fdebug('using %s() to create optimizer node for tech %s', this[f]?f:'createDefaultOptimizerNode', tech);
+        LOGGER.fdebug('Using %s() to create optimizer node for tech %s', f, tech);
 
-        return (this[f] ||
-            this.createDefaultOptimizerNode).call(this, tech, sourceNode, bundleNode);
+        return this[f].apply(this, arguments);
+
     },
 
     linkNodes: function(techTargets) {
@@ -127,7 +131,7 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
             var d = deps[i];
 
             if (!this.ctx.arch.hasNode(d)) {
-                LOGGER.fverbose('dependency %s is required to build %s but does not exist, checking if target already built', d, node.getId());
+                LOGGER.fverbose('Dependency %s is required to build %s but does not exist, checking if target already built', d, node.getId());
 
                 if (!PATH.existsSync(node.getPath())) {
                     LOGGER.fwarn('%s will not be built because dependency file %s does not exist', node.path, d);
@@ -150,19 +154,20 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
      *
      * @param techName
      * @param techPath
-     * @param declTech
+     * @param declPath
      * @param {String} bundleNode
      * @param {String} magicNode
      * @param {Boolean} [forked]
      * @return {String} ID of the node that has been created
      */
-    setBemBuildNode: function(techName, techPath, declTech, bundleNode, magicNode, forked) {
+    setBemBuildNode: function(techName, techPath, declPath, bundleNode, magicNode, forked) {
+
         var arch = this.ctx.arch,
             buildNode = new BemBuildNode({
                 root: this.root,
                 bundlesLevel: this.level,
                 levels: this.getLevels(PATH.resolve(this.root, this.getNodePrefix())),
-                declPath: this.getBundlePath(declTech),
+                declPath: declPath,
                 techPath: techPath,
                 techName: techName,
                 output: this.getNodePrefix(),
@@ -174,14 +179,25 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
         bundleNode && arch.addParents(buildNode, bundleNode);
         magicNode && arch.addChildren(buildNode, magicNode);
 
-        arch.setNode(buildNode.getMetaNode(),
-            buildNode,
-            this.getBundlePath(declTech));
+        arch.setNode(buildNode.getMetaNode(), buildNode, declPath);
 
         return buildNode;
+
     },
 
-    createDefaultNode: function(tech, bundleNode, magicNode) {
+    createDefaultTechNode: function(tech, bundleNode, magicNode) {
+
+        return this.setBemBuildNode(
+            tech,
+            this.level.resolveTech(tech),
+            this.getBundlePath('deps.js'),
+            bundleNode,
+            magicNode);
+
+    },
+
+    'create-bemjson.js-node': function(tech, bundleNode, magicNode) {
+
         var arch = this.ctx.arch,
             filePath = this.getBundlePath(tech);
 
@@ -198,9 +214,11 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
         magicNode && arch.addChildren(node, magicNode);
 
         return node;
+
     },
 
     'create-bemdecl.js-node': function(tech, bundleNode, magicNode) {
+
         var arch = this.ctx.arch,
             node = this.useFileOrBuild(new BemCreateNode({
                 root: this.root,
@@ -218,14 +236,22 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
         magicNode && arch.addChildren(node, magicNode);
 
         return node;
+
     },
 
     'create-deps.js-node': function(tech, bundleNode, magicNode) {
-        var techPath = this.level.resolveTech(tech);
-        return this.setBemBuildNode(tech, techPath, 'bemdecl.js', bundleNode, magicNode);
+
+        return this.setBemBuildNode(
+            tech,
+            this.level.resolveTech(tech),
+            this.getBundlePath('bemdecl.js'),
+            bundleNode,
+            magicNode);
+
     },
 
     'create-html-node': function(tech, bundleNode, magicNode) {
+
         // TODO: move node to bem-bl/blocks-common/i-bem/bem
         var arch = this.ctx.arch,
             node = this.useFileOrBuild(new BemCreateNode({
@@ -245,33 +271,13 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
         magicNode && arch.addChildren(node, magicNode);
 
         return node;
+
     },
 
-    'create-bemhtml.js-node': function(tech, bundleNode, magicNode) {
-        // TODO: move node to bem-bl/blocks-common/i-bem/bem
-        var techPath = this.level.resolveTech(tech);
-        LOGGER.fdebug('techpath for tech %s is %s', tech, techPath);
-        return this.setBemBuildNode(tech, techPath, 'deps.js', bundleNode, magicNode, true);
-    },
-
-    'create-js-node': function(tech, bundleNode, magicNode) {
-        var techPath = this.level.resolveTech(tech);
-        return this.setBemBuildNode(tech, techPath, 'deps.js', bundleNode, magicNode);
-    },
-
-    'create-css-node': function(tech, bundleNode, magicNode) {
-        var techPath = this.level.resolveTech(tech);
-        return this.setBemBuildNode(tech, techPath, 'deps.js', bundleNode, magicNode);
-    },
-
-    'create-ie.css-node': function(tech, bundleNode, magicNode) {
-        return this['create-css-node'].apply(this, arguments);
-    },
-
-    createDefaultOptimizerNode: function(tech, sourceNode, bundleNode) {
-    },
+    createDefaultOptimizerNode: function(tech, sourceNode, bundleNode) {},
 
     'create-js-optimizer-node': function(tech, sourceNode, bundleNode) {
+
         LOGGER.fdebug('Creating borschik node for %s', sourceNode.getId());
 
         var node = new (registry.getNodeClass('BorschikNode'))({
@@ -287,9 +293,15 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
             .addChildren(node, sourceNode);
 
         return node;
+
+    },
+
+    'create-priv.js-optimizer-node': function(tech, sourceNode, bundleNode) {
+        return this['create-js-optimizer-node'].apply(this, arguments);
     },
 
     'create-css-optimizer-node': function(tech, sourceNode, bundleNode) {
+
         LOGGER.fdebug('Creating borschik node for %s', sourceNode.getId());
 
         var node = new (registry.getNodeClass('BorschikNode'))({
@@ -305,14 +317,35 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
             .addChildren(node, sourceNode);
 
         return node;
+
     },
 
     'create-ie.css-optimizer-node': function(tech, sourceNode, bundleNode) {
-        var node = this['create-css-optimizer-node'](tech, sourceNode, bundleNode);
 
+        var node = this['create-css-optimizer-node'].apply(this, arguments);
         this.ctx.arch.addChildren(node, this.getBundlePath('css'));
-
         return node;
+
+    },
+
+    'create-ie6.css-optimizer-node': function(tech, sourceNode, bundleNode) {
+
+        var node = this['create-ie.css-optimizer-node'].apply(this, arguments);
+        this.ctx.arch.addChildren(node, this.getBundlePath('ie.css'));
+        return node;
+
+    },
+
+    'create-ie7.css-optimizer-node': function(tech, sourceNode, bundleNode) {
+        return this['create-ie6.css-optimizer-node'].apply(this, arguments);
+    },
+
+    'create-ie8.css-optimizer-node': function(tech, sourceNode, bundleNode) {
+        return this['create-ie6.css-optimizer-node'].apply(this, arguments);
+    },
+
+    'create-ie9.css-optimizer-node': function(tech, sourceNode, bundleNode) {
+        return this['create-ie.css-optimizer-node'].apply(this, arguments);
     }
 
 });

--- a/lib/nodes/bundle.js
+++ b/lib/nodes/bundle.js
@@ -132,16 +132,16 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
     },
 
     /**
-     * Create a bem build node, add it to the arch,
-     * then creates a meta node and link it to the build node.
+     * Create a bem build node, add it to the arch, add
+     * dependencies to it. Then create a meta node and link
+     * it to the build node.
      *
-     * @param techName
-     * @param techPath
-     * @param declPath
+     * @param {String} techName
+     * @param {String} techPath
+     * @param {String} declPath
      * @param {String} bundleNode
      * @param {String} magicNode
      * @param {Boolean} [forked]
-     * @return {String} ID of the node that has been created
      */
     setBemBuildNode: function(techName, techPath, declPath, bundleNode, magicNode, forked) {
 

--- a/lib/nodes/bundle.js
+++ b/lib/nodes/bundle.js
@@ -172,18 +172,47 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
 
     },
 
-    createDefaultTechNode: function(tech, bundleNode, magicNode) {
+    /**
+     * Create a bem create node, add it to the arch,
+     * add dependencies to it.
+     *
+     * @param {String} techName
+     * @param {String} techPath
+     * @param {String} bundleNode
+     * @param {String} magicNode
+     */
+    setBemCreateNode: function(techName, techPath, bundleNode, magicNode) {
 
-        return this.setBemBuildNode(
-            tech,
-            this.level.resolveTech(tech),
-            this.getBundlePath('deps.js'),
-            bundleNode,
-            magicNode);
+        var arch = this.ctx.arch,
+            node = this.useFileOrBuild(new BemCreateNode({
+                root: this.root,
+                level: this.level,
+                item: this.item,
+                techPath: techPath,
+                techName: techName
+            }));
+
+        if (!node) return;
+
+        // Set bem create node to arch and add dependencies to it
+        arch.setNode(node)
+            .addChildren(node, node.getDependencies());
+
+        bundleNode && arch.addParents(node, bundleNode);
+        magicNode && arch.addChildren(node, magicNode);
+
+        return node;
 
     },
 
-    'create-bemjson.js-node': function(tech, bundleNode, magicNode) {
+    /**
+     * Create file node, add it to the arch, add dependencies to it.
+     *
+     * @param {String} tech
+     * @param {String} bundleNode
+     * @param {String} magicNode
+     */
+    setFileNode: function(tech, bundleNode, magicNode) {
 
         var arch = this.ctx.arch,
             filePath = this.getBundlePath(tech);
@@ -204,27 +233,30 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
 
     },
 
+    createDefaultTechNode: function(tech, bundleNode, magicNode) {
+
+        return this.setBemBuildNode(
+            tech,
+            this.level.resolveTech(tech),
+            this.getBundlePath('deps.js'),
+            bundleNode,
+            magicNode);
+
+    },
+
+    createDefaultOptimizerNode: function(tech, sourceNode, bundleNode) {},
+
+    'create-bemjson.js-node': function(tech, bundleNode, magicNode) {
+        return this.setFileNode.apply(this, arguments);
+    },
+
     'create-bemdecl.js-node': function(tech, bundleNode, magicNode) {
 
-        var arch = this.ctx.arch,
-            node = this.useFileOrBuild(new BemCreateNode({
-                root: this.root,
-                level: this.level,
-                item: this.item,
-                techPath: this.level.resolveTech(tech),
-                techName: tech
-            }));
-
-        if (!node) return;
-
-        // Set bem create node to arch and add dependencies to it
-        arch.setNode(node)
-            .addChildren(node, node.getDependencies());
-
-        bundleNode && arch.addParents(node, bundleNode);
-        magicNode && arch.addChildren(node, magicNode);
-
-        return node;
+        return this.setBemCreateNode(
+            tech,
+            this.level.resolveTech(tech),
+            bundleNode,
+            magicNode);
 
     },
 
@@ -241,31 +273,13 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
 
     'create-html-node': function(tech, bundleNode, magicNode) {
 
-        // TODO: move node to bem-bl/blocks-common/i-bem/bem
-        var arch = this.ctx.arch,
-            node = this.useFileOrBuild(new BemCreateNode({
-                root: this.root,
-                level: this.level,
-                item: this.item,
-                techPath: this.level.resolveTech(tech),
-                techName: tech,
-                force: true
-            }));
-
-        if (!node) return;
-
-        // Set bem create node to arch and add dependencies to it
-        arch.setNode(node)
-            .addChildren(node, node.getDependencies());
-
-        bundleNode && arch.addParents(node, bundleNode);
-        magicNode && arch.addChildren(node, magicNode);
-
-        return node;
+        return this.setBemCreateNode(
+            tech,
+            this.level.resolveTech(tech),
+            bundleNode,
+            magicNode);
 
     },
-
-    createDefaultOptimizerNode: function(tech, sourceNode, bundleNode) {},
 
     'create-js-optimizer-node': function(tech, sourceNode, bundleNode) {
 

--- a/lib/nodes/bundle.js
+++ b/lib/nodes/bundle.js
@@ -1,33 +1,26 @@
 var Q = require('q'),
     INHERIT = require('inherit'),
-    UTIL = require('../util'),
+    U = require('../util'),
     PATH = require('path'),
-    createLevel = require('../index').createLevel,
 
-    MagicNode = require('./magic').MagicNode,
+    BlockNode = require('./block').BlockNode,
     FileNode = require('./file').FileNode,
     BemCreateNode = require('./create').BemCreateNode,
     BemBuildNode = require('./build').BemBuildNode,
     registry = require('../make').NodesRegistry,
     LOGGER = require('../logger');
 
-var BundleNode = exports.BundleNode = INHERIT(MagicNode, {
+var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
 
-    __constructor: function(level, bundleNameOrItem, subBundleName) {
-        this.level = typeof level == 'string'? createLevel(level) : level;
+    make: function() {
 
-        this.item = (typeof bundleNameOrItem === 'string')? createItem(bundleNameOrItem, subBundleName) : bundleNameOrItem;
-
-        this.__base(PATH.dirname(this.getNodePrefix()));
-    },
-
-    make: function(ctx) {
-
-        return ctx.arch.withLock(this.alterArch(ctx), this);
+        return this.ctx.arch.withLock(this.alterArch(), this);
 
     },
 
-    alterArch: function(ctx) {
+    alterArch: function() {
+
+        var ctx = this.ctx;
 
         return function() {
 
@@ -38,23 +31,26 @@ var BundleNode = exports.BundleNode = INHERIT(MagicNode, {
             if (arch.hasNode(this.path)) {
                 bundleNode = arch.getNode(this.path);
             } else {
-                bundleNode = new FileNode(this.path);
+                bundleNode = new FileNode({
+                    root: this.root,
+                    path: this.path
+                });
                 arch.setNode(bundleNode, arch.getParents(this));
             }
 
             // generate targets for page files
             var techTargets = {};
             this.getTechs().map(function(tech) {
-                var techNode = this.createNode(ctx, tech, bundleNode, this);
+                var techNode = this.createNode(tech, bundleNode, this);
                 if (techNode) {
                     techTargets[tech] = techNode.getId();
-                    this.createOptimizerNode(ctx, tech, bundleNode, techNode);
+                    this.createOptimizerNode(tech, bundleNode, techNode);
                 }
             }, this);
 
             // link targets for page files with each other
             // FIXME: rewrite, move linking to create*() methods
-            return this.linkNodes(ctx, techTargets);
+            return this.linkNodes(techTargets);
         };
 
     },
@@ -63,30 +59,30 @@ var BundleNode = exports.BundleNode = INHERIT(MagicNode, {
         return Q.resolve(0);
     },
 
-    createNode: function(ctx, tech, bundleNode, magicNode) {
+    createNode: function(tech, bundleNode, magicNode) {
         var f = 'create-' + tech + '-node';
 
         LOGGER.fdebug('using %s() to create node for tech %s', this[f]?f:'createDefaultNode', tech);
 
         return (this[f] ||
-            this.createDefaultNode).call(this, ctx, tech, bundleNode, magicNode);
+            this.createDefaultNode).call(this, tech, bundleNode, magicNode);
     },
 
-    createOptimizerNode: function(ctx, tech, bundleNode, sourceNode) {
+    createOptimizerNode: function(tech, bundleNode, sourceNode) {
         var f = 'create-' + tech + '-optimizer-node';
 
         LOGGER.fdebug('using %s() to create optimizer node for tech %s', this[f]?f:'createDefaultOptimizerNode', tech);
 
         return (this[f] ||
-            this.createDefaultOptimizerNode).call(this, ctx, tech, sourceNode, bundleNode);
+            this.createDefaultOptimizerNode).call(this, tech, sourceNode, bundleNode);
     },
 
-    linkNodes: function(ctx, techTargets) {
-        var arch = ctx.arch;
+    linkNodes: function(techTargets) {
+        var arch = this.ctx.arch;
         return Q.all(Object.keys(techTargets).map(function(target) {
             var targetNode = arch.getNode(techTargets[target]);
             if (targetNode.getCreateDependencies)
-                return Q.when(targetNode.getCreateDependencies(ctx), function(deps) {
+                return Q.when(targetNode.getCreateDependencies(), function(deps) {
                     for(var d = 0; d < deps.length; d++) {
                         if (!arch.hasNode(deps[d])) continue;
                         arch.addParents(deps[d], techTargets[target]);
@@ -112,17 +108,10 @@ var BundleNode = exports.BundleNode = INHERIT(MagicNode, {
         ];
     },
 
-    cleanup: function(ctx) {
-        var arch = ctx.arch;
+    cleanup: function() {
+        var arch = this.ctx.arch;
         if (!arch.hasNode(this.path)) return;
         arch.removeTree(this.path);
-    },
-
-    getNodePrefix: function() {
-        if (!this._nodePrefix) {
-            this._nodePrefix = this.__self._createId(this.level, this.item);
-        }
-        return this._nodePrefix;
     },
 
     getLevels: function(prefix) {
@@ -131,21 +120,24 @@ var BundleNode = exports.BundleNode = INHERIT(MagicNode, {
             [ PATH.join(PATH.dirname(prefix), 'blocks') ]);
     },
 
-    useFileOrBuild: function(node, ctx) {
-        var deps = node.getCreateDependencies(ctx);
+    useFileOrBuild: function(node) {
+        var deps = node.getCreateDependencies();
 
         for(var i = 0; i < deps.length; i++) {
             var d = deps[i];
 
-            if (!ctx.arch.hasNode(d)) {
+            if (!this.ctx.arch.hasNode(d)) {
                 LOGGER.fverbose('dependency %s is required to build %s but does not exist, checking if target already built', d, node.getId());
 
-                if (!PATH.existsSync(PATH.resolve(ctx.root, node.getId()))) {
+                if (!PATH.existsSync(PATH.resolve(this.ctx.root, node.getId()))) {
                     LOGGER.fwarn('%s will not be built because dependency file %s does not exist', node.getId(), d);
                     return null;
                 }
 
-                return new FileNode(node.getId());
+                return new FileNode({
+                    root: this.root,
+                    path: node.getId()
+                });
             }
         }
 
@@ -156,7 +148,6 @@ var BundleNode = exports.BundleNode = INHERIT(MagicNode, {
      * Create a bem build node, add it to the arch,
      * then creates a meta node and link it to the build node.
      *
-     * @param ctx
      * @param techName
      * @param techPath
      * @param declTech
@@ -165,16 +156,18 @@ var BundleNode = exports.BundleNode = INHERIT(MagicNode, {
      * @param {Boolean} [forked]
      * @return {String} ID of the node that has been created
      */
-    setBemBuildNode: function(ctx, techName, techPath, declTech, bundleNode, magicNode, forked) {
-        var arch = ctx.arch,
-            buildNode = new BemBuildNode(
-                this.level,
-                this.getLevels(PATH.resolve(ctx.root, this.getNodePrefix())),
-                this.getBundlePath(declTech),
-                techPath,
-                techName,
-                this.getNodePrefix(),
-                forked);
+    setBemBuildNode: function(techName, techPath, declTech, bundleNode, magicNode, forked) {
+        var arch = this.ctx.arch,
+            buildNode = new BemBuildNode({
+                root: this.root,
+                bundlesLevel: this.level,
+                levels: this.getLevels(PATH.resolve(this.root, this.getNodePrefix())),
+                declPath: this.getBundlePath(declTech),
+                techPath: techPath,
+                techName: techName,
+                output: this.getNodePrefix(),
+                forked: forked
+            });
 
         arch.setNode(buildNode);
 
@@ -188,13 +181,16 @@ var BundleNode = exports.BundleNode = INHERIT(MagicNode, {
         return buildNode;
     },
 
-    createDefaultNode: function(ctx, tech, bundleNode, magicNode) {
-        var arch = ctx.arch,
+    createDefaultNode: function(tech, bundleNode, magicNode) {
+        var arch = this.ctx.arch,
             filePath = this.getBundlePath(tech);
 
-        if (!PATH.existsSync(PATH.resolve(ctx.root, filePath))) return;
+        if (!PATH.existsSync(PATH.resolve(this.ctx.root, filePath))) return;
 
-        var node = new FileNode(filePath);
+        var node = new FileNode({
+            root: this.root,
+            path: filePath
+        });
 
         arch.setNode(node);
 
@@ -204,11 +200,15 @@ var BundleNode = exports.BundleNode = INHERIT(MagicNode, {
         return node;
     },
 
-    'create-bemdecl.js-node': function(ctx, tech, bundleNode, magicNode) {
-        var arch = ctx.arch,
-            node = this.useFileOrBuild(
-                new BemCreateNode(this.level, this.item, tech, tech),
-                ctx);
+    'create-bemdecl.js-node': function(tech, bundleNode, magicNode) {
+        var arch = this.ctx.arch,
+            node = this.useFileOrBuild(new BemCreateNode({
+                root: this.root,
+                level: this.level,
+                item: this.item,
+                techPath: this.level.resolveTech(tech),
+                techName: tech
+            }));
 
         if (!node) return;
 
@@ -220,22 +220,22 @@ var BundleNode = exports.BundleNode = INHERIT(MagicNode, {
         return node;
     },
 
-    'create-deps.js-node': function(ctx, tech, bundleNode, magicNode) {
+    'create-deps.js-node': function(tech, bundleNode, magicNode) {
         var techPath = this.level.resolveTech(tech);
-        return this.setBemBuildNode(ctx, tech, techPath, 'bemdecl.js', bundleNode, magicNode);
+        return this.setBemBuildNode(tech, techPath, 'bemdecl.js', bundleNode, magicNode);
     },
 
-    'create-html-node': function(ctx, tech, bundleNode, magicNode) {
+    'create-html-node': function(tech, bundleNode, magicNode) {
         // TODO: move node to bem-bl/blocks-common/i-bem/bem
-        var arch = ctx.arch,
-            node = this.useFileOrBuild(
-                new BemCreateNode(
-                    this.level,
-                    this.item,
-                    this.level.resolveTech(tech),
-                    tech,
-                    true),
-                ctx);
+        var arch = this.ctx.arch,
+            node = this.useFileOrBuild(new BemCreateNode({
+                root: this.root,
+                level: this.level,
+                item: this.item,
+                techPath: this.level.resolveTech(tech),
+                techName: tech,
+                force: true
+            }));
 
         if (!node) return;
 
@@ -245,39 +245,43 @@ var BundleNode = exports.BundleNode = INHERIT(MagicNode, {
         magicNode && arch.addChildren(node, magicNode);
 
         return node;
-
     },
 
-    'create-bemhtml.js-node': function(ctx, tech, bundleNode, magicNode) {
+    'create-bemhtml.js-node': function(tech, bundleNode, magicNode) {
         // TODO: move node to bem-bl/blocks-common/i-bem/bem
         var techPath = this.level.resolveTech(tech);
         LOGGER.fdebug('techpath for tech %s is %s', tech, techPath);
-        return this.setBemBuildNode(ctx, tech, techPath, 'deps.js', bundleNode, magicNode, true);
+        return this.setBemBuildNode(tech, techPath, 'deps.js', bundleNode, magicNode, true);
     },
 
-    'create-js-node': function(ctx, tech, bundleNode, magicNode) {
+    'create-js-node': function(tech, bundleNode, magicNode) {
         var techPath = this.level.resolveTech(tech);
-        return this.setBemBuildNode(ctx, tech, techPath, 'deps.js', bundleNode, magicNode);
+        return this.setBemBuildNode(tech, techPath, 'deps.js', bundleNode, magicNode);
     },
 
-    'create-css-node': function(ctx, tech, bundleNode, magicNode) {
+    'create-css-node': function(tech, bundleNode, magicNode) {
         var techPath = this.level.resolveTech(tech);
-        return this.setBemBuildNode(ctx, tech, techPath, 'deps.js', bundleNode, magicNode);
+        return this.setBemBuildNode(tech, techPath, 'deps.js', bundleNode, magicNode);
     },
 
-    'create-ie.css-node': function(ctx, tech, bundleNode, magicNode) {
+    'create-ie.css-node': function(tech, bundleNode, magicNode) {
         return this['create-css-node'].apply(this, arguments);
     },
 
-    createDefaultOptimizerNode: function(ctx, tech, sourceNode, bundleNode) {
+    createDefaultOptimizerNode: function(tech, sourceNode, bundleNode) {
     },
 
-    'create-js-optimizer-node': function(ctx, tech, sourceNode, bundleNode) {
+    'create-js-optimizer-node': function(tech, sourceNode, bundleNode) {
         LOGGER.fdebug('Creating borschik node for %s', sourceNode.getId());
 
-        var node = new (registry.getNodeClass('BorschikNode'))(sourceNode, 'js', true);
+        var node = new (registry.getNodeClass('BorschikNode'))({
+            root: this.root,
+            sourceNode: sourceNode,
+            tech: 'js',
+            forked: true
+        });
 
-        ctx.arch
+        this.ctx.arch
             .setNode(node)
             .addParents(node, bundleNode)
             .addChildren(node, sourceNode);
@@ -285,12 +289,17 @@ var BundleNode = exports.BundleNode = INHERIT(MagicNode, {
         return node;
     },
 
-    'create-css-optimizer-node': function(ctx, tech, sourceNode, bundleNode) {
+    'create-css-optimizer-node': function(tech, sourceNode, bundleNode) {
         LOGGER.fdebug('Creating borschik node for %s', sourceNode.getId());
 
-        var node = new (registry.getNodeClass('BorschikNode'))(sourceNode, 'css-fast', true);
+        var node = new (registry.getNodeClass('BorschikNode'))({
+            root: this.root,
+            sourceNode: sourceNode,
+            tech: 'css-fast',
+            forked: true
+        });
 
-        ctx.arch
+        this.ctx.arch
             .setNode(node)
             .addParents(node, bundleNode)
             .addChildren(node, sourceNode);
@@ -298,32 +307,12 @@ var BundleNode = exports.BundleNode = INHERIT(MagicNode, {
         return node;
     },
 
-    'create-ie.css-optimizer-node': function(ctx, tech, sourceNode, bundleNode) {
-        var node = this['create-css-optimizer-node'](ctx, tech, sourceNode, bundleNode);
+    'create-ie.css-optimizer-node': function(tech, sourceNode, bundleNode) {
+        var node = this['create-css-optimizer-node'](tech, sourceNode, bundleNode);
 
-        ctx.arch.addChildren(node, this.getBundlePath('css'));
+        this.ctx.arch.addChildren(node, this.getBundlePath('css'));
 
         return node;
-    }
-
-}, {
-
-    createId: function(level, bundleNameOrItem, subBundleName) {
-        return this.__base(PATH.dirname(this._createId(level, bundleNameOrItem, subBundleName)));
-    },
-
-    _createId:  function(level, bundleNameOrItem, subBundleName) {
-        return UTIL.getNodePrefix(
-            (typeof level == 'string')? createLevel(level) : level,
-            (typeof bundleNameOrItem === 'string')? createItem(bundleNameOrItem, subBundleName) : bundleNameOrItem);
     }
 
 });
-
-function createItem(bundleName, subBundleName) {
-    var item = { block: bundleName };
-
-    if (subBundleName) item.elem = subBundleName;
-
-    return item;
-}

--- a/lib/nodes/bundle.js
+++ b/lib/nodes/bundle.js
@@ -39,18 +39,13 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
             }
 
             // generate targets for page files
-            var techTargets = {};
             this.getTechs().map(function(tech) {
                 var techNode = this.createTechNode(tech, bundleNode, this);
                 if (techNode) {
-                    techTargets[tech] = techNode.getId();
                     this.createOptimizerNode(tech, techNode, bundleNode);
                 }
             }, this);
 
-            // link targets for page files with each other
-            // FIXME: rewrite, move linking to create*() methods
-            return this.linkNodes(techTargets);
         };
 
     },
@@ -79,20 +74,6 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
 
         return this[f].apply(this, arguments);
 
-    },
-
-    linkNodes: function(techTargets) {
-        var arch = this.ctx.arch;
-        return Q.all(Object.keys(techTargets).map(function(target) {
-            var targetNode = arch.getNode(techTargets[target]);
-            if (targetNode.getCreateDependencies)
-                return Q.when(targetNode.getCreateDependencies(), function(deps) {
-                    for(var d = 0; d < deps.length; d++) {
-                        if (!arch.hasNode(deps[d])) continue;
-                        arch.addParents(deps[d], techTargets[target]);
-                    }
-                });
-        }));
     },
 
     getBundlePath: function(tech) {
@@ -125,9 +106,10 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
     },
 
     useFileOrBuild: function(node) {
-        var deps = node.getCreateDependencies();
 
-        for(var i = 0; i < deps.length; i++) {
+        var deps = node.getDependencies();
+
+        for(var i = 0, l = deps.length; i < l; i++) {
             var d = deps[i];
 
             if (!this.ctx.arch.hasNode(d)) {
@@ -146,6 +128,7 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
         }
 
         return node;
+
     },
 
     /**
@@ -234,7 +217,9 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
 
         if (!node) return;
 
-        arch.setNode(node);
+        // Set bem create node to arch and add dependencies to it
+        arch.setNode(node)
+            .addChildren(node, node.getDependencies());
 
         bundleNode && arch.addParents(node, bundleNode);
         magicNode && arch.addChildren(node, magicNode);
@@ -269,7 +254,9 @@ var BundleNode = exports.BundleNode = INHERIT(BlockNode, {
 
         if (!node) return;
 
-        arch.setNode(node);
+        // Set bem create node to arch and add dependencies to it
+        arch.setNode(node)
+            .addChildren(node, node.getDependencies());
 
         bundleNode && arch.addParents(node, bundleNode);
         magicNode && arch.addChildren(node, magicNode);

--- a/lib/nodes/create.js
+++ b/lib/nodes/create.js
@@ -10,7 +10,9 @@ exports.BemCreateNode = INHERIT(GeneratedFileNode, {
 
     __constructor: function(o) {
 
-        this.level = typeof o.level === 'string'? createLevel(o.level) : o.level;
+        this.level = typeof o.level === 'string'?
+            createLevel(PATH.resolve(o.root, o.level)) :
+            o.level;
         this.item = o.item;
         this.tech = this.level.getTech(o.techName, o.techPath);
         this.force = !!o.force || false;
@@ -77,25 +79,28 @@ exports.BemCreateNode = INHERIT(GeneratedFileNode, {
 }, {
 
     createId: function(o) {
-
-        o.path = o.path || this.createPath(o);
-        return this.__base(o);
-
+        return this.createPath(o);
     },
 
     createPath: function(o) {
 
-        return (typeof o.level === 'string'? createLevel(o.level) : o.level)
+        var level = typeof o.level === 'string'?
+            createLevel(PATH.resolve(o.root, o.level)) :
+            o.level;
+
+        return level
             .getTech(o.techName, o.techPath)
-            .getPath(this.createNodePrefix(o));
+            .getPath(this.createNodePrefix(U.extend({}, o, { level: level })));
 
     },
 
     createNodePrefix: function(o) {
 
-        return PATH.join(
-            PATH.relative(o.root, o.level.dir),
-            o.level.getRelByObj(o.item));
+        var level = typeof o.level === 'string'?
+            createLevel(PATH.resolve(o.root, o.level)) :
+            o.level;
+
+        return PATH.relative(o.root, level.getByObj(o.item));
 
     }
 

--- a/lib/nodes/create.js
+++ b/lib/nodes/create.js
@@ -68,7 +68,7 @@ exports.BemCreateNode = INHERIT(GeneratedFileNode, {
         };
     },
 
-    getCreateDependencies: function() {
+    getDependencies: function() {
 
         return this.tech.getDependencies().map(function(d) {
             return this.level.getPath(this.getNodePrefix(), d);

--- a/lib/nodes/create.js
+++ b/lib/nodes/create.js
@@ -2,19 +2,21 @@ var INHERIT = require('inherit'),
     PATH = require('path'),
     BEM = require('../coa').api,
     createLevel = require('../level').createLevel,
+    U = require('../util'),
 
     GeneratedFileNode = require('./file').GeneratedFileNode;
 
 exports.BemCreateNode = INHERIT(GeneratedFileNode, {
 
-    __constructor: function(level, item, techPath, techName, force) {
-        this.level = typeof level == 'string'? createLevel(level) : level;
-        this.item = item;
-        this.tech = this.level.getTech(techName, techPath);
-        this.force = !!force || false;
+    __constructor: function(o) {
 
-        this.prefix = PATH.join(PATH.basename(this.level.dir), this.level.getRelByObj(this.item));
-        this.__base(this.tech.getPath(this.prefix));
+        this.level = typeof o.level === 'string'? createLevel(o.level) : o.level;
+        this.item = o.item;
+        this.tech = this.level.getTech(o.techName, o.techPath);
+        this.force = !!o.force || false;
+
+        this.__base(U.extend({ path: this.__self.createPath(o) }, o));
+
     },
 
     make: function() {
@@ -26,6 +28,19 @@ exports.BemCreateNode = INHERIT(GeneratedFileNode, {
         this.log('bem.create.%s(%s, %s)', p.cmd, JSON.stringify(p.opts, null, 4), JSON.stringify(p.args, null, 4));
 
         return BEM.create[p.cmd](p.opts, p.args);
+    },
+
+    getNodePrefix: function(o) {
+
+        if (!this._nodePrefix) {
+            this._nodePrefix = this.__self.createNodePrefix(o || {
+                root: this.root,
+                level: this.level,
+                item: this.item
+            });
+        }
+        return this._nodePrefix;
+
     },
 
     parseItem: function(item) {
@@ -51,12 +66,37 @@ exports.BemCreateNode = INHERIT(GeneratedFileNode, {
         };
     },
 
-    getCreateDependencies: function(ctx) {
-        var _this = this;
+    getCreateDependencies: function() {
 
-        return this.tech.getDependencies().map(function(d){
-            return _this.level.getTech(d).getPath(_this.prefix);
-        });
+        return this.tech.getDependencies().map(function(d) {
+            return this.level.getPath(this.getNodePrefix(), d);
+        }, this);
+
+    }
+
+}, {
+
+    createId: function(o) {
+
+        o.path = o.path || this.createPath(o);
+        return this.__base(o);
+
+    },
+
+    createPath: function(o) {
+
+        return (typeof o.level === 'string'? createLevel(o.level) : o.level)
+            .getTech(o.techName, o.techPath)
+            .getPath(this.createNodePrefix(o));
+
+    },
+
+    createNodePrefix: function(o) {
+
+        return PATH.join(
+            PATH.relative(o.root, o.level.dir),
+            o.level.getRelByObj(o.item));
+
     }
 
 });

--- a/lib/nodes/file.js
+++ b/lib/nodes/file.js
@@ -7,30 +7,56 @@ var Q = require('q'),
 
     Node = require('./node').Node;
 
-var FileNode = exports.FileNode = INHERIT(Node, {
+var FileNode = exports.FileNode = INHERIT(Node, /** @lends FileNode.prototype */ {
 
+    /**
+     * Verbosity of node log messages.
+     * @type {String}
+     */
     buildMessageVerbosity: 'verbose',
 
+    /**
+     * FileNode instance constructor.
+     *
+     * @class Node base class.
+     * @constructs
+     * @param {Object} o  Node options.
+     */
     __constructor: function(o) {
         this.__base(o);
         this.root = o.root;
         this.path = o.path;
     },
 
+    /**
+     * Get absolute path of file represented by this node.
+     *
+     * @return {String}
+     */
     getPath: function() {
         return PATH.resolve(this.root, this.path);
     },
 
+    /**
+     * make() implementation.
+     *
+     * @return {Promise * Undefined}
+     */
     make: function() {
 
         var _this = this;
         return QFS.exists(this.getPath())
             .then(function(exists) {
-                if (!exists) return Q.reject(UTIL.format("Path %j doesn't exist", _this.getPath()));
+                if (!exists) return Q.reject(UTIL.format("make error: Path %j doesn't exist", _this.getPath()));
             });
 
     },
 
+    /**
+     * Get file mtime in milliseconds or -1 in case of file doesn't exist.
+     *
+     * @return {Promise * Number}
+     */
     lastModified: function() {
 
         return QFS.lastModified(this.getPath())
@@ -40,22 +66,37 @@ var FileNode = exports.FileNode = INHERIT(Node, {
 
     }
 
-}, {
+}, /** @lends FileNode */ {
 
+    /**
+     * Create node id.
+     *
+     * @param {Object} o  Node options.
+     * @return {String}   Node id.
+     */
     createId: function(o) {
         return o.path;
     }
 
 });
 
-exports.GeneratedFileNode = INHERIT(FileNode, {
+exports.GeneratedFileNode = INHERIT(FileNode, /** @lends GeneratedFileNode.prototype */ {
 
+    /**
+     * Verbosity of node log messages.
+     * @type {String}
+     */
     buildMessageVerbosity: 'info',
 
+    /**
+     * isValid() implementation.
+     *
+     * @return {Promise * Boolean}  Node validity state (true if node is valid).
+     */
     isValid: function() {
 
-        if (this.ctx.method && this.ctx.method != 'make') return false;
-        if (this.ctx.force) return false;
+        if (this.ctx.method && this.ctx.method != 'make') return Q.resolve(false);
+        if (this.ctx.force) return Q.resolve(false);
 
         var arch = this.ctx.arch,
             parent = this.lastModified(),
@@ -69,7 +110,7 @@ exports.GeneratedFileNode = INHERIT(FileNode, {
 
         // with no deps we must always check for file existance
         // isValid() == false will guarantee it
-        if (!children.length) return false;
+        if (!children.length) return Q.resolve(false);
 
         var _this = this;
         return Q.all([parent].concat(children)).then(function(all) {
@@ -82,8 +123,22 @@ exports.GeneratedFileNode = INHERIT(FileNode, {
 
     },
 
-    make: function() {},
+    /**
+     * make() implementation.
+     *
+     * Should not be removed because of FileNode has
+     * its own implementation that must be overriden.
+     *
+     * @returns {Promise * Undefined}
+     */
+    make: function() {
+        return Q.resolve();
+    },
 
+    /**
+     * clean() implementation.
+     * @return {Promise * Undefined}
+     */
     clean: function() {
 
         var _this = this;

--- a/lib/nodes/file.js
+++ b/lib/nodes/file.js
@@ -11,30 +11,39 @@ var FileNode = exports.FileNode = INHERIT(Node, {
 
     buildMessageVerbosity: 'verbose',
 
-    __constructor: function(path, optional) {
-        this.path = path;
-        this.optional = optional || false;
-        this.__base(path);
+    __constructor: function(o) {
+        this.__base(o);
+        this.root = o.root;
+        this.path = o.path;
     },
 
     getPath: function() {
-        return this.path;
+        return PATH.resolve(this.root, this.path);
     },
 
-    make: function(ctx) {
-        if (this.optional) return;
+    make: function() {
 
         var _this = this;
-        return QFS.exists(PATH.resolve(ctx.root, this.getPath()))
+        return QFS.exists(this.getPath())
             .then(function(exists) {
                 if (!exists) return Q.reject(UTIL.format("Path %j doesn't exist", _this.getPath()));
             });
+
     },
 
-    lastModified: function(ctx) {
-        return QFS.lastModified(PATH.resolve(ctx.root, this.getPath())).fail(function() {
-            return -1;
-        });
+    lastModified: function() {
+
+        return QFS.lastModified(this.getPath())
+            .fail(function() {
+                return -1;
+            });
+
+    }
+
+}, {
+
+    createId: function(o) {
+        return o.path;
     }
 
 });
@@ -43,18 +52,19 @@ exports.GeneratedFileNode = INHERIT(FileNode, {
 
     buildMessageVerbosity: 'info',
 
-    isValid: function(ctx) {
-        if (ctx.method && ctx.method != 'make') return false;
-        if (ctx.force) return false;
+    isValid: function() {
 
-        var arch = ctx.arch,
-            parent = this.lastModified(ctx),
+        if (this.ctx.method && this.ctx.method != 'make') return false;
+        if (this.ctx.force) return false;
+
+        var arch = this.ctx.arch,
+            parent = this.lastModified(),
             children = arch.getChildren(this)
                 .filter(function(child) {
                     return (child && (arch.getNode(child)) instanceof FileNode);
                 })
                 .map(function(child) {
-                    return arch.getNode(child).lastModified(ctx);
+                    return arch.getNode(child).lastModified();
                 });
 
         // with no deps we must always check for file existance
@@ -69,17 +79,20 @@ exports.GeneratedFileNode = INHERIT(FileNode, {
             LOGGER.fdebug('*** isValid(%s): cur=%s, max=%s, valid=%s', _this.getId(), cur, max, cur >= max && max > -1);
             return cur >= max && max > -1;
         });
+
     },
 
     make: function() {},
 
-    clean: function(ctx) {
+    clean: function() {
+
         var _this = this;
-        return QFS.remove(PATH.join(ctx.root, this.getId()))
+        return QFS.remove(this.getPath())
             .then(function() {
                 LOGGER.fverbose('Removed %j', _this.getId());
             })
             .fail(function() {});
+
     }
 
 });

--- a/lib/nodes/index.js
+++ b/lib/nodes/index.js
@@ -16,6 +16,8 @@ exports.BemBuildNode = require('./build').BemBuildNode;
 exports.BemBuildForkedNode = require('./build').BemBuildForkedNode;
 
 exports.LibraryNode = require('./lib').LibraryNode;
+exports.SymlinkLibraryNode = require('./lib').SymlinkLibraryNode;
+exports.ScmLibraryNode = require('./lib').ScmLibraryNode;
 exports.GitLibraryNode = require('./lib').GitLibraryNode;
 exports.SvnLibraryNode = require('./lib').SvnLibraryNode;
 

--- a/lib/nodes/level.js
+++ b/lib/nodes/level.js
@@ -1,5 +1,6 @@
 var INHERIT = require('inherit'),
     PATH = require('path'),
+    U = require('../util'),
     createLevel = require('../level').createLevel,
 
     MagicNode = require('./magic').MagicNode,
@@ -11,14 +12,14 @@ var INHERIT = require('inherit'),
 var LevelNode = exports.LevelNode = INHERIT(MagicNode, {
 
     __constructor: function(o) {
-        this.root = o.root;
+
         this.level = typeof o.level == 'string'?
-            createLevel(PATH.resolve(this.root, o.level)) :
+            createLevel(PATH.resolve(o.root, o.level)) :
             o.level;
         this.lastTimeDecl = [];
 
-        o.path = this.__self.createPath(this);
-        this.__base(o);
+        this.__base(U.extend({ path: this.__self.createPath(o) }, o));
+
     },
 
     itemNodeClassName: 'BlockNode',
@@ -141,7 +142,7 @@ var LevelNode = exports.LevelNode = INHERIT(MagicNode, {
 
     createPath: function(o) {
 
-        var level = typeof o.level == 'string'?
+        var level = typeof o.level === 'string'?
             createLevel(PATH.resolve(o.root, o.level)) :
             o.level;
 

--- a/lib/nodes/level.js
+++ b/lib/nodes/level.js
@@ -10,22 +10,28 @@ var INHERIT = require('inherit'),
 
 var LevelNode = exports.LevelNode = INHERIT(MagicNode, {
 
-    __constructor: function(level) {
-        this.level = typeof level == 'string'? createLevel(level) : level;
+    __constructor: function(o) {
+        this.root = o.root;
+        this.level = typeof o.level == 'string'?
+            createLevel(PATH.resolve(this.root, o.level)) :
+            o.level;
         this.lastTimeDecl = [];
-        // TODO: path relative to the project root must be passed
-        this.__base(PATH.basename(this.level.dir));
+
+        o.path = this.__self.createPath(this);
+        this.__base(o);
     },
 
     itemNodeClassName: 'BlockNode',
 
-    make: function(ctx) {
+    make: function() {
 
-        return ctx.arch.withLock(this.alterArch(ctx), this);
+        return this.ctx.arch.withLock(this.alterArch(), this);
 
     },
 
-    alterArch: function(ctx) {
+    alterArch: function() {
+
+        var ctx = this.ctx;
 
         return function() {
 
@@ -39,7 +45,10 @@ var LevelNode = exports.LevelNode = INHERIT(MagicNode, {
             if (arch.hasNode(this.path)) {
                 levelNode = arch.getNode(this.path);
             } else {
-                levelNode = new FileNode(this.path);
+                levelNode = new FileNode({
+                    root: this.root,
+                    path: this.path
+                });
                 arch.setNode(levelNode, arch.getParents(this));
             }
 
@@ -48,40 +57,59 @@ var LevelNode = exports.LevelNode = INHERIT(MagicNode, {
 
             // collect level items into a hash to speedup futher checks
             decl.map(function(d) {
-                declIds[itemNodeClass.createId(this.level, d.name)] = true;
+
+                var id = itemNodeClass.createId({
+                    root: this.root,
+                    level: this.level,
+                    item: { block: d.name }
+                });
+
+                declIds[id] = true;
+
             }, this);
 
             // build a hash from decl array got during previous alterArch call
             // put the nodes which are not present in the decl anymore into an array for futher removal
             var lastTimeDeclHash = {},
                 nodesToRemove = [];
-            this.lastTimeDecl.forEach(function(d){
-                var id = itemNodeClass.createId(this.level, d.name);
+
+            this.lastTimeDecl.forEach(function(d) {
+
+                var id = itemNodeClass.createId({
+                    root: this.root,
+                    level: this.level,
+                    item: { block: d.name }
+                });
+
                 if (!declIds[id]) nodesToRemove.push(id);
                 lastTimeDeclHash[d.name] = d;
+
             }, this);
 
             // remove collected nodes
             nodesToRemove.forEach(function(n){
+
                 var node = arch.getNode(n);
-                node.cleanup && node.cleanup(ctx);
+                node.cleanup && node.cleanup();
                 arch.removeTree(n);
+
             });
 
             // iterate through decl nodes and create the ones which don't present in the arch yet
             decl.forEach(function(block) {
 
-                if (!arch.hasNode(itemNodeClass.createId(this.level, block.name))) {
+                var o = {
+                    root: this.root,
+                    level: this.level,
+                    item: { block: block.name }
+                };
 
-                    arch.setNode(
-                        new itemNodeClass(this.level, block.name),
-                        levelNode,
-                        this);
+                if (!arch.hasNode(itemNodeClass.createId(o))) {
+                    arch.setNode(new itemNodeClass(o), levelNode, this);
                 }
 
                 // actualize nodes for current block elements
                 this.actualizeElements(
-                    ctx,
                     block,
                     lastTimeDeclHash[block.name],
                     levelNode);
@@ -93,17 +121,34 @@ var LevelNode = exports.LevelNode = INHERIT(MagicNode, {
 
     },
 
-    actualizeElements: function(ctx, newBlockDecl, oldBlockDecl, node) {
+    actualizeElements: function(newBlockDecl, oldBlockDecl, node) {
 
     },
 
-    cleanup: function(ctx) {
-        var arch = ctx.arch;
+    cleanup: function() {
 
+        var arch = this.ctx.arch;
         if (!arch.hasNode(this.path)) return;
-
         arch.removeTree(this.path);
+
     }
+
+}, {
+
+    createId: function(o) {
+        return this.createPath(o) + '*';
+    },
+
+    createPath: function(o) {
+
+        var level = typeof o.level == 'string'?
+            createLevel(PATH.resolve(o.root, o.level)) :
+            o.level;
+
+        return PATH.relative(o.root, level.dir);
+
+    }
+
 });
 
 
@@ -111,17 +156,30 @@ exports.BundlesLevelNode = INHERIT(LevelNode, {
 
     itemNodeClassName: 'BundleNode',
 
-    actualizeElements: function(ctx, newBlockDecl, oldBlockDecl, node) {
-        var arch = ctx.arch,
+    actualizeElements: function(newBlockDecl, oldBlockDecl, node) {
+
+        var arch = this.ctx.arch,
             declIds = {},
             itemNodeClass = registry.getNodeClass(this.itemNodeClassName);
 
         // collect elements decl ids into hash
         if (newBlockDecl.elems) {
-            newBlockDecl.elems.map(function(d) {
-                var id = itemNodeClass.createId(this.level, newBlockDecl.name, d.name);
+
+            newBlockDecl.elems.map(function(elem) {
+
+                var id = itemNodeClass.createId({
+                    root: this.root,
+                    level: this.level,
+                    item: {
+                        block: newBlockDecl.name,
+                        elem: elem.name
+                    }
+                });
+
                 declIds[id] = true;
+
             }, this);
+
         }
 
         var lastTimeDeclHash = {},
@@ -130,30 +188,53 @@ exports.BundlesLevelNode = INHERIT(LevelNode, {
         // if previous block elements decl is defined collect the outdated nodes for removal,
         // hash previous block decl
         if (oldBlockDecl && oldBlockDecl.elems) {
-            oldBlockDecl.elems.forEach(function(d){
-                var id = itemNodeClass.createId(this.level, newBlockDecl.name, d.name);
+
+            oldBlockDecl.elems.forEach(function(elem) {
+
+                var id = itemNodeClass.createId({
+                    root: this.root,
+                    level: this.level,
+                    item: {
+                        block: oldBlockDecl.name,
+                        elem: elem.name
+                    }
+                });
+
                 if (!declIds[id]) nodesToRemove.push(id);
-                lastTimeDeclHash[d.name] = d;
+                lastTimeDeclHash[elem.name] = elem;
+
             }, this);
 
             nodesToRemove.forEach(function(n){
                 var node = arch.getNode(n);
-                node.cleanup && node.cleanup(ctx);
+                node.cleanup && node.cleanup();
                 arch.removeTree(n);
             });
+
         }
 
         // iterate through new block elements decl and create new nodes
         if (newBlockDecl.elems) {
+
             newBlockDecl.elems.forEach(function(elem) {
 
-                if (!arch.hasNode(itemNodeClass.createId(this.level, newBlockDecl.name, elem.name))) {
-                    arch.setNode(
-                        new itemNodeClass(this.level, newBlockDecl.name, elem.name),
-                        node,
-                        this);
+                var o = {
+                    root: this.root,
+                    level: this.level,
+                    item: {
+                        block: newBlockDecl.name,
+                        elem: elem.name
+                    }
+                };
+
+                if (!arch.hasNode(itemNodeClass.createId(o))) {
+                    arch.setNode(new itemNodeClass(o), node, this);
                 }
+
             }, this);
+
         }
+
     }
+
 });

--- a/lib/nodes/lib.js
+++ b/lib/nodes/lib.js
@@ -6,90 +6,237 @@ var Q = require('q'),
     URL = require('url'),
     UTIL = require('util'),
 
-    Node = require('./node').Node;
+    Node = require('./node').Node,
 
-var LibraryNode = exports.LibraryNode = INHERIT(Node, {
+    SCM_VALIDITY_TIMEOUT = 60000; // 60 secs
 
-    __constructor: function(dest, repo, paths, treeish) {
-        this.dest = dest;
-        this.repo = repo;
-        this.treeish = treeish || '';
+var LibraryNode = exports.LibraryNode = INHERIT(Node, /** @lends LibraryNode.prototype */ {
 
-        paths = Array.isArray(paths)? paths : [paths];
-        this.paths = paths || [''];
-
-        this.__base(this.dest);
+    /**
+     * LibraryNode instance constructor.
+     *
+     * @class LibraryNode
+     * @constructs
+     * @param {Object} o  Node options.
+     * @param {String} o.root    Project root path.
+     * @param {String} o.target  Library path.
+     */
+    __constructor: function(o) {
+        this.__base(o);
+        this.root = o.root;
+        this.target = o.target;
     },
 
-    getInitialCheckoutCmd: function(repo, dest) {},
+    /**
+     * Get absolute path to library.
+     *
+     * @return {String}
+     */
+    getPath: function() {
+        return PATH.resolve(this.root, this.target);
+    }
 
-    getUpdateCmd: function(repo, dest) {},
+}, {
 
-    isValid: function() {
-        return this.lastRunTime && (Date.now() - this.lastRunTime <= 60000);
-    },
-
-    make: function(ctx) {
-        var _this = this;
-
-        return Q.all(this.paths.map(function(p) {
-            var dest = PATH.join(ctx.root, _this.dest, p),
-                repo = joinUrlPath(_this.repo, p);
-
-            return QFS.exists(dest)
-                .then(function(exists){
-                    var cmd = exists? _this.getUpdateCmd(repo, dest) : _this.getInitialCheckoutCmd(repo, dest),
-                        d = Q.defer();
-
-                    _this.log(cmd);
-
-                    CP.exec(cmd, function(err, stdout, stderr) {
-                        stdout && _this.log(stdout);
-                        stderr && _this.log(stderr);
-
-                        if (err) return d.reject(err);
-
-                        _this.lastRunTime = Date.now();
-                        d.resolve();
-                    });
-
-                    return d.promise;
-                });
-        }));
+    createId: function(o) {
+        return o.target;
     }
 
 });
 
-exports.GitLibraryNode = INHERIT(LibraryNode, {
+exports.SymlinkLibraryNode = INHERIT(LibraryNode, /** @lends SymlinkLibraryNode.prototype */ {
 
-    __constructor: function(dest, repo, paths, treeish) {
-        this.__base(dest, repo, paths, treeish);
-        this.treeish = treeish || 'master';
+    /**
+     * SymlinkLibraryNode instance constructor.
+     *
+     * @class SymlinkLibraryNode
+     * @constructs
+     * @param {Object} o  Node options.
+     * @param {String} o.root      Project root path.
+     * @param {String} o.target    Library path.
+     * @param {String} o.relative  Symlink path.
+     */
+    __constructor: function(o) {
+        this.__base(o);
+        this.relative = o.relative;
     },
 
-    getInitialCheckoutCmd: function(repo, dest) {
-        return UTIL.format('git clone --progress %s %s && cd %s && git checkout %s', repo, dest, dest, this.treeish);
+    /**
+     * Check validity of node.
+     *
+     * @return {Boolean}
+     */
+    isValid: function() {
+        return false;
     },
 
-    getUpdateCmd: function(repo, dest) {
+    /**
+     * Make node.
+     *
+     * @return {Promise * Undefined}
+     */
+    make: function() {
+
+        var _this = this;
+        return QFS.statLink(this.getPath())
+            .fail(function() {
+                return false;
+            })
+            .then(function(stat) {
+
+                if (!stat) return;
+
+                if (!stat.isSymbolicLink()) {
+                    return Q.reject(UTIL.format("SymlinkLibraryNode: Path '%s' is exists and is not a symbolic link",
+                        _this.getPath()));
+                }
+
+                return QFS.remove(_this.getPath());
+
+            })
+            .then(function() {
+                return QFS.symbolicLink(_this.getPath(), _this.relative);
+            });
+
+    }
+
+});
+
+var ScmLibraryNode = exports.ScmLibraryNode = INHERIT(LibraryNode, /** @lends ScmLibraryNode.prototype */ {
+
+    /**
+     * ScmLibraryNode instance constructor.
+     *
+     * @class ScmLibraryNode
+     * @constructs
+     * @param {Object} o  Node options.
+     * @param {String} o.root      Project root path.
+     * @param {String} o.target    Library path.
+     * @param {String} o.repo      Repository URL.
+     * @param {String[]} [o.paths=['']]  Paths to checkout.
+     */
+    __constructor: function(o) {
+        this.__base(o);
+        this.repo = o.repo;
+        this.paths = [''];
+        this.timeout = typeof o.timeout !== 'undefined'? Number(o.timeout) : SCM_VALIDITY_TIMEOUT;
+    },
+
+    /**
+     * Check validity of node.
+     *
+     * @return {Boolean}
+     */
+    isValid: function() {
+        return this.lastRunTime && this.timeout && (Date.now() - this.lastRunTime <= this.timeout);
+    },
+
+    getInitialCheckoutCmd: function(repo, target) {},
+
+    getUpdateCmd: function(repo, target) {},
+
+    updatePath: function(path) {
+
+        var _this = this,
+            target = PATH.resolve(this.root, this.target, path),
+            repo = joinUrlPath(this.repo, path);
+
+        return QFS.exists(target)
+            .then(function(exists) {
+
+                var cmd = exists?
+                        _this.getUpdateCmd(repo, target) :
+                        _this.getInitialCheckoutCmd(repo, target),
+                    d = Q.defer();
+
+                _this.log(cmd);
+
+                CP.exec(cmd, function(err, stdout, stderr) {
+                    stdout && _this.log(stdout);
+                    stderr && _this.log(stderr);
+
+                    if (err) return d.reject(err);
+
+                    _this.lastRunTime = Date.now();
+                    d.resolve();
+                });
+
+                return d.promise;
+
+            });
+
+    },
+
+    /**
+     * Make node.
+     *
+     * @return {Promise * Undefined}
+     */
+    make: function() {
+
+        return Q.all(this.paths.map(function(path) {
+            return this.updatePath(path);
+        }, this));
+
+    }
+
+});
+
+exports.GitLibraryNode = INHERIT(ScmLibraryNode, /** @lends GitLibraryNode.prototype */ {
+
+    /**
+     * GitLibraryNode instance constructor.
+     *
+     * @class GitLibraryNode
+     * @constructs
+     * @param {Object} o  Node options.
+     * @param {String} o.root      Project root path.
+     * @param {String} o.target    Library path.
+     * @param {String} o.repo      Repository URL.
+     * @param {String[]} [o.paths=['']]  Paths to checkout.
+     * @param {String} [o.treeish='master']  Treeish to checkout.
+     */
+    __constructor: function(o) {
+        this.__base(o);
+        this.treeish = o.treeish || 'master';
+    },
+
+    getInitialCheckoutCmd: function(repo, target) {
+        return UTIL.format('git clone --progress %s %s && cd %s && git checkout %s', repo, target, target, this.treeish);
+    },
+
+    getUpdateCmd: function(repo, target) {
         return UTIL.format('cd %s && git checkout HEAD~ && git branch -D %s ; git fetch origin && git checkout --track -b %s origin/%s', dest, this.treeish, this.treeish, this.treeish);
     }
 
 });
 
-exports.SvnLibraryNode = INHERIT(LibraryNode, {
+exports.SvnLibraryNode = INHERIT(LibraryNode, /** @lends SvnLibraryNode.prototype */ {
 
-    __constructor: function(dest, repo, paths, treeish) {
-        this.__base(dest, repo, paths, treeish);
-        this.treeish = treeish || 'HEAD';
+    /**
+     * SvnLibraryNode instance constructor.
+     *
+     * @class SvnLibraryNode
+     * @constructs
+     * @param {Object} o  Node options.
+     * @param {String} o.root      Project root path.
+     * @param {String} o.target    Library path.
+     * @param {String} o.repo      Repository URL.
+     * @param {String[]} [o.paths=['']]  Paths to checkout.
+     * @param {String} [o.revision='HEAD']  Revision to checkout.
+     */
+    __constructor: function(o) {
+        this.__base(o);
+        this.paths = Array.isArray(o.paths)? o.paths : [o.paths || ''];
+        this.revision = o.revision || 'HEAD';
     },
 
-    getInitialCheckoutCmd: function(repo, dest) {
-        return UTIL.format('svn co -q -r %s %s %s', this.treeish, repo, dest);
+    getInitialCheckoutCmd: function(repo, target) {
+        return UTIL.format('svn co -q -r %s %s %s', this.revision, repo, target);
     },
 
-    getUpdateCmd: function(repo, dest) {
-        return UTIL.format('svn up -q -r %s %s', this.treeish, dest);
+    getUpdateCmd: function(repo, target) {
+        return UTIL.format('svn up -q -r %s %s', this.revision, target);
     }
 
 });

--- a/lib/nodes/lib.js
+++ b/lib/nodes/lib.js
@@ -131,10 +131,34 @@ var ScmLibraryNode = exports.ScmLibraryNode = INHERIT(LibraryNode, /** @lends Sc
         return this.lastRunTime && this.timeout && (Date.now() - this.lastRunTime <= this.timeout);
     },
 
-    getInitialCheckoutCmd: function(url, target) {},
+    /**
+     * Stub for getInitialCheckoutCmd(), throws.
+     *
+     * @param {String} url  Repository url.
+     * @param {String} target  Repository checkout path.
+     * @throws {Error}
+     */
+    getInitialCheckoutCmd: function(url, target) {
+        throw new Error('getInitialCheckoutCmd() not implemented!');
+    },
 
-    getUpdateCmd: function(url, target) {},
+    /**
+     * Stub for getUpdateCmd(), throws.
+     *
+     * @param {String} url  Repository url.
+     * @param {String} target  Repository checkout path.
+     * @throws {Error}
+     */
+    getUpdateCmd: function(url, target) {
+        throw new Error('getInitialCheckoutCmd() not implemented!');
+    },
 
+    /**
+     * Checkput or update single repository path.
+     *
+     * @param {String} path  Repository path to checkout / update.
+     * @return {Promise * Undefined}
+     */
     updatePath: function(path) {
 
         var _this = this,

--- a/lib/nodes/lib.js
+++ b/lib/nodes/lib.js
@@ -112,12 +112,12 @@ var ScmLibraryNode = exports.ScmLibraryNode = INHERIT(LibraryNode, /** @lends Sc
      * @param {Object} o  Node options.
      * @param {String} o.root      Project root path.
      * @param {String} o.target    Library path.
-     * @param {String} o.repo      Repository URL.
+     * @param {String} o.url       Repository URL.
      * @param {String[]} [o.paths=['']]  Paths to checkout.
      */
     __constructor: function(o) {
         this.__base(o);
-        this.repo = o.repo;
+        this.url = o.url;
         this.paths = [''];
         this.timeout = typeof o.timeout !== 'undefined'? Number(o.timeout) : SCM_VALIDITY_TIMEOUT;
     },
@@ -131,15 +131,15 @@ var ScmLibraryNode = exports.ScmLibraryNode = INHERIT(LibraryNode, /** @lends Sc
         return this.lastRunTime && this.timeout && (Date.now() - this.lastRunTime <= this.timeout);
     },
 
-    getInitialCheckoutCmd: function(repo, target) {},
+    getInitialCheckoutCmd: function(url, target) {},
 
-    getUpdateCmd: function(repo, target) {},
+    getUpdateCmd: function(url, target) {},
 
     updatePath: function(path) {
 
         var _this = this,
             target = PATH.resolve(this.root, this.target, path),
-            repo = joinUrlPath(this.repo, path);
+            repo = joinUrlPath(this.url, path);
 
         return QFS.exists(target)
             .then(function(exists) {
@@ -192,7 +192,7 @@ exports.GitLibraryNode = INHERIT(ScmLibraryNode, /** @lends GitLibraryNode.proto
      * @param {Object} o  Node options.
      * @param {String} o.root      Project root path.
      * @param {String} o.target    Library path.
-     * @param {String} o.repo      Repository URL.
+     * @param {String} o.url       Repository URL.
      * @param {String[]} [o.paths=['']]  Paths to checkout.
      * @param {String} [o.treeish='master']  Treeish to checkout.
      */
@@ -201,12 +201,12 @@ exports.GitLibraryNode = INHERIT(ScmLibraryNode, /** @lends GitLibraryNode.proto
         this.treeish = o.treeish || 'master';
     },
 
-    getInitialCheckoutCmd: function(repo, target) {
-        return UTIL.format('git clone --progress %s %s && cd %s && git checkout %s', repo, target, target, this.treeish);
+    getInitialCheckoutCmd: function(url, target) {
+        return UTIL.format('git clone --progress %s %s && cd %s && git checkout %s', url, target, target, this.treeish);
     },
 
-    getUpdateCmd: function(repo, target) {
-        return UTIL.format('cd %s && git checkout HEAD~ && git branch -D %s ; git fetch origin && git checkout --track -b %s origin/%s', dest, this.treeish, this.treeish, this.treeish);
+    getUpdateCmd: function(url, target) {
+        return UTIL.format('cd %s && git checkout HEAD~ && git branch -D %s ; git fetch origin && git checkout --track -b %s origin/%s', target, this.treeish, this.treeish, this.treeish);
     }
 
 });
@@ -221,7 +221,7 @@ exports.SvnLibraryNode = INHERIT(LibraryNode, /** @lends SvnLibraryNode.prototyp
      * @param {Object} o  Node options.
      * @param {String} o.root      Project root path.
      * @param {String} o.target    Library path.
-     * @param {String} o.repo      Repository URL.
+     * @param {String} o.url       Repository URL.
      * @param {String[]} [o.paths=['']]  Paths to checkout.
      * @param {String} [o.revision='HEAD']  Revision to checkout.
      */
@@ -231,11 +231,11 @@ exports.SvnLibraryNode = INHERIT(LibraryNode, /** @lends SvnLibraryNode.prototyp
         this.revision = o.revision || 'HEAD';
     },
 
-    getInitialCheckoutCmd: function(repo, target) {
-        return UTIL.format('svn co -q -r %s %s %s', this.revision, repo, target);
+    getInitialCheckoutCmd: function(url, target) {
+        return UTIL.format('svn co -q -r %s %s %s', this.revision, url, target);
     },
 
-    getUpdateCmd: function(repo, target) {
+    getUpdateCmd: function(url, target) {
         return UTIL.format('svn up -q -r %s %s', this.revision, target);
     }
 

--- a/lib/nodes/magic.js
+++ b/lib/nodes/magic.js
@@ -1,25 +1,52 @@
-var INHERIT = require('inherit'),
-
+var Q = require('q'),
+    INHERIT = require('inherit'),
     FileNode = require('./file').FileNode;
 
-exports.MagicNode = INHERIT(FileNode, {
+exports.MagicNode = INHERIT(FileNode, /** @lends MagicNode.prototype */ {
 
+    /**
+     * Verbosity of node log messages.
+     * @type {String}
+     */
     buildMessageVerbosity: 'verbose',
 
+    /**
+     * clean() implementation.
+     *
+     * Forwards call to #make().
+     *
+     * @return {Promise * Undefined}
+     */
     clean: function() {
         return this.make();
     },
 
+    /**
+     * isValid() implementation.
+     *
+     * @return {Promise * Boolean}  Node validity state (true if node is valid).
+     */
     isValid: function() {
-        return false;
+        return Q.resolve(false);
     },
 
+    /**
+     * lastModified() stub that always returns promised -1.
+     *
+     * @return {Promise * Number}
+     */
     lastModified: function() {
-        return -1;
+        return Q.resolve(-1);
     }
 
-}, {
+}, /** @lends MagicNode */ {
 
+    /**
+     * Create node id.
+     *
+     * @param {Object} o  Node options.
+     * @return {String}   Node id.
+     */
     createId: function(o) {
         return this.__base(o) + '*';
     }

--- a/lib/nodes/magic.js
+++ b/lib/nodes/magic.js
@@ -6,15 +6,11 @@ exports.MagicNode = INHERIT(FileNode, {
 
     buildMessageVerbosity: 'verbose',
 
-    getId: function() {
-        return this.id + '*';
+    clean: function() {
+        return this.make();
     },
 
-    clean: function(ctx) {
-        return this.make(ctx);
-    },
-
-    isValid: function(ctx) {
+    isValid: function() {
         return false;
     },
 
@@ -24,8 +20,8 @@ exports.MagicNode = INHERIT(FileNode, {
 
 }, {
 
-    createId: function(id) {
-        return id + '*';
+    createId: function(o) {
+        return this.__base(o) + '*';
     }
 
 });

--- a/lib/nodes/node.js
+++ b/lib/nodes/node.js
@@ -126,6 +126,15 @@ exports.Node = INHERIT(/** @lends Node.prototype */ {
      */
     dumpLog: function() {
         LOGGER.verbose(this.formatLog());
+    },
+
+    /**
+     * Get node dependencies.
+     *
+     * @returns {String[]|Object}
+     */
+    getDependencies: function() {
+        return [];
     }
 
 }, /** @lends Node */ {

--- a/lib/nodes/node.js
+++ b/lib/nodes/node.js
@@ -7,16 +7,17 @@ exports.Node = INHERIT({
 
     buildMessageVerbosity: 'info',
 
-    __constructor: function(id) {
-        this.id = id;
+    __constructor: function(o) {
+        this.id = this.__self.createId(o);
     },
 
     getId: function() {
         return this.id;
     },
 
-    run: function(ctx) {
+    run: function() {
         var _this = this,
+            ctx = this.ctx,
             method = ctx.method || 'make';
 
         this.clearLog();
@@ -26,7 +27,7 @@ exports.Node = INHERIT({
             LOGGER.time('[t] isValid() time for "%s" [%s]', this.getId(), ctx.plan.getId());
         }
 
-        return Q.when(this.isValid(ctx), function(valid) {
+        return Q.when(this.isValid(), function(valid) {
             LOGGER.fverbose("[?] Node '%s' is %s [%s]", _this.getId(), valid? 'valid' : 'expired', ctx.plan.getId());
             if (_this.buildMessageVerbosity === 'info') {
                 LOGGER.timeEnd('[t] isValid() time for "%s" [%s]', _this.getId(), ctx.plan.getId());
@@ -35,7 +36,7 @@ exports.Node = INHERIT({
 
             LOGGER.flog(_this.buildMessageVerbosity, "[*] %s '%s' [%s]", method, _this.getId(), ctx.plan.getId());
             _this.log("[=] Log of %s '%s' [%s]", method, _this.getId(), ctx.plan.getId());
-            return Q.invoke(_this, method, ctx).then(function(res) {
+            return Q.invoke(_this, method).then(function(res) {
                 _this.dumpLog();
 
                 if (_this.buildMessageVerbosity === 'info') {
@@ -47,11 +48,11 @@ exports.Node = INHERIT({
         });
     },
 
-    make: function(ctx) {},
+    make: function() {},
 
-    clean: function(ctx) {},
+    clean: function() {},
 
-    isValid: function(ctx) {
+    isValid: function() {
         return false;
     },
 
@@ -73,6 +74,12 @@ exports.Node = INHERIT({
 
     dumpLog: function() {
         LOGGER.verbose(this.formatLog());
+    }
+
+}, {
+
+    createId: function(o) {
+        return o;
     }
 
 });

--- a/lib/nodes/node.js
+++ b/lib/nodes/node.js
@@ -3,18 +3,39 @@ var Q = require('q'),
     UTIL = require('util'),
     LOGGER = require('../logger');
 
-exports.Node = INHERIT({
+exports.Node = INHERIT(/** @lends Node.prototype */ {
 
+    /**
+     * Verbosity of node log messages.
+     * @type {String}
+     */
     buildMessageVerbosity: 'info',
 
+    /**
+     * Node instance constructor.
+     *
+     * @class Node base class.
+     * @constructs
+     * @param {Object} o  Node options.
+     */
     __constructor: function(o) {
         this.id = this.__self.createId(o);
     },
 
+    /**
+     * Get node id.
+     *
+     * @return {String}
+     */
     getId: function() {
         return this.id;
     },
 
+    /**
+     * Generic implementation of node run() method.
+     *
+     * @return {Promise * Undefined}
+     */
     run: function() {
         var _this = this,
             ctx = this.ctx,
@@ -48,14 +69,34 @@ exports.Node = INHERIT({
         });
     },
 
-    make: function() {},
-
-    clean: function() {},
-
-    isValid: function() {
-        return false;
+    /**
+     * make() method stub.
+     */
+    make: function() {
+        return Q.resolve();
     },
 
+    /**
+     * clean() method stub.
+     */
+    clean: function() {
+        return Q.resolve();
+    },
+
+    /**
+     * isValid() method default implementation thay always returns promised false.
+     *
+     * @returns {Promise * Boolean}
+     */
+    isValid: function() {
+        return Q.resolve(false);
+    },
+
+    /**
+     * Store message into node messages container.
+     *
+     * @param {String[]|String} messages  Message or array of messages to log.
+     */
     log: function(messages) {
         messages = Array.isArray(messages)? messages : [messages];
         var args = Array.prototype.slice.call(arguments, 1);
@@ -64,20 +105,37 @@ exports.Node = INHERIT({
         }));
     },
 
+    /**
+     * Clear node messages container.
+     */
     clearLog: function() {
         delete this.messages;
     },
 
+    /**
+     * Return messages from node container as a single string.
+     *
+     * @return {String}
+     */
     formatLog: function() {
         return (this.messages || []).join('\n');
     },
 
+    /**
+     * Dump all messages from node container to logger.
+     */
     dumpLog: function() {
         LOGGER.verbose(this.formatLog());
     }
 
-}, {
+}, /** @lends Node */ {
 
+    /**
+     * Create node id.
+     *
+     * @param {Object} o  Node options.
+     * @return {String}   Node id.
+     */
     createId: function(o) {
         return o;
     }

--- a/test/nodes-lib.js
+++ b/test/nodes-lib.js
@@ -1,0 +1,70 @@
+var assert = require('chai').assert,
+    U = require('util'),
+    PATH = require('path'),
+    QFS = require('q-fs'),
+
+    SymlinkLibraryNode = require('../lib/nodes').SymlinkLibraryNode;
+
+/**
+ * Mocha BDD interface.
+ *
+ * @name describe @function
+ * @name it @function
+ * @name before @function
+ * @name after @function
+ * @name beforeEach @function
+ * @name afterEach @function
+ */
+
+describe('nodes', function() {
+
+    describe('new SymlinkLibraryNode()', function() {
+
+        var node = new SymlinkLibraryNode({
+                root: PATH.resolve(__dirname, 'data'),
+                target: 'symlink',
+                relative: 'lib'
+            }),
+            symlink = PATH.resolve(__dirname, 'data', 'symlink');
+
+        describe('.getId()', function() {
+            it('equals to target', function() {
+                assert.equal(node.getId(), 'symlink');
+            });
+        });
+
+        describe('.getPath()', function() {
+            it('equals to absolute path to target', function() {
+                assert.equal(node.getPath(), symlink);
+            });
+        });
+
+        describe('.make()', function() {
+
+            afterEach(function() {
+                QFS.remove(symlink);
+            });
+
+            it('creates symlink', function(done) {
+
+                node.make()
+                    .then(function() {
+
+                        return QFS.statLink(symlink)
+                            .then(function(stat) {
+                                assert.ok(stat.isSymbolicLink());
+                                done();
+                            })
+                            .fail(done);
+
+                    })
+                    .fail(done)
+                    .end();
+
+            });
+
+        });
+
+    });
+
+});


### PR DESCRIPTION
- use `this.ctx` instead of methods argument
- pass project root to constructor of all nodes
- all node constructors accept object with options instead of positional arguments
