### PR TITLE
Refactor introspection logic

### DIFF
--- a/lib/level.js
+++ b/lib/level.js
@@ -636,23 +636,102 @@ var Level = exports.Level = INHERIT(/** @lends Level.prototype */{
     /**
      * Get declaration of level directory or one of its subdirectories.
      *
-     * @param {String} from  Relative path to subdirectory of level directory.
+     * @param {String} [from]  Relative path to subdirectory of level directory to start introspection from.
      * @return {Array}  Array of declaration.
      */
     getDeclByIntrospection: function(from) {
-        from = PATH.resolve(this.dir, from || '.');
-        var decl = [];
 
-        bemUtil.fsWalkTree(from, function(f) {
-            var match = this.matchAny(f);
-            if(match && match.tech) {
-                decl = this._mergeMatchToDecl(match, decl);
+        this._declIntrospector || (this._declIntrospector = this.createIntrospector({
+
+            creator: function(res, match) {
+                if (match && match.tech) {
+                    return this._mergeMatchToDecl(match, res);
+                }
+                return res;
             }
-        }, function(f) {
-            return !this.isIgnorablePath(f);
-        }, this);
 
-        return decl;
+        }));
+
+        return this._declIntrospector(from);
+    },
+
+    /**
+     * Get BEM entities from level directory or one of its subdirectories.
+     *
+     * @param {String} [from]  Relative path to subdirectory of level directory to start introspection from.
+     * @return {Array}  Array of entities.
+     */
+    getItemsByIntrospection: function(from) {
+
+        this._itemsIntrospector || (this._itemsIntrospector = this.createIntrospector());
+        return this._itemsIntrospector(from);
+
+    },
+
+    /**
+     * Creates preconfigured introspection functions.
+     *
+     * @param {Object} [opts]  Introspector options.
+     * @param {String} [opts.from]  Relative path to subdirectory of level directory to start introspection from.
+     * @param {Function} [opts.init]  Function to return initial value of introspection.
+     * @param {Function} [opts.filter]  Function to filter paths to introspect, must return {Boolean}.
+     * @param {Function} [opts.matcher]  Function to perform match of paths, must return introspected value.
+     * @param {Function} [opts.creator]  Function to modify introspection object with matched value, must return new introspection.
+     * @return {Function}  Introspection function.
+     */
+    createIntrospector: function(opts) {
+
+        var level = this;
+
+        // clone opts
+        opts = bemUtil.extend({}, opts);
+
+        // set default options
+        opts.from || (opts.from = '.');
+
+        // initial value initializer
+        opts.init || (opts.init = function() {
+            return [];
+        });
+
+        // paths filter function
+        opts.filter || (opts.filter = function(path) {
+            return !this.isIgnorablePath(path);
+        });
+
+        // matcher function
+        opts.matcher || (opts.matcher = function(path) {
+            return this.matchAny(path);
+        });
+
+        // result creator function
+        opts.creator || (opts.creator = function(res, match) {
+            if (match && match.tech) res.push(match);
+            return res;
+        });
+
+        /**
+         * Introspection function.
+         *
+         * @param {String} [from]  Relative path to subdirectory of level directory to start introspection from.
+         * @param {*} [res]  Initial introspection value to extend.
+         * @return {*}
+         */
+        return function(from, res) {
+
+            from = PATH.resolve(level.dir, from || opts.from);
+            res || (res = opts.init.call(level));
+
+            bemUtil.fsWalkTree(from, function(path) {
+                    res = opts.creator.call(level, res, opts.matcher.call(level, path));
+                },
+                opts.filter,
+                level);
+
+            return res;
+
+        };
+
     },
 
     /**

--- a/test/level.js
+++ b/test/level.js
@@ -190,6 +190,28 @@ describe('level', function() {
             });
         });
 
+        describe(".createIntrospector() default introspector call", function() {
+            it("returns correct introspection", function() {
+                assert.deepEqual(level.createIntrospector()(), [
+                    {
+                        block: 'first-block',
+                        elem: 'elem1',
+                        mod: 'mod2',
+                        suffix: '.css',
+                        tech: 'css'
+                    },
+                    {
+                        block: 'first-block',
+                        elem: 'elem1',
+                        mod: 'mod2',
+                        val: '3',
+                        suffix: '.js',
+                        tech: 'js'
+                    }
+                ]);
+            });
+        });
+
         describe(".match-*()", function() {
             level.matchOrder().forEach(function(matcher) {
 


### PR DESCRIPTION
- Add `createIntrospector()` method to `Level` class to create custom introspectors (see jsdoc)
- Refactor `getDeclByIntrospection()` to use `createIntrospector()`
- Add `getItemsByIntrospection()` method to `Level` class, that returns array of BEM entities in techs
- Add tests for default introspector
