### PR TITLE
Adding node.js tech for using bem with backend on node/express

### DIFF
--- a/lib/nodes/bundle.js
+++ b/lib/nodes/bundle.js
@@ -378,6 +378,10 @@ registry.decl(BundleNodeName, BlockNode, /** @lends BundleNode.prototype */ {
     'create-bemhtml.js-optimizer-node': function(tech, sourceNode, bundleNode) {
         return this['create-bemhtml-optimizer-node'].apply(this, arguments);
     },
+    
+    'create-node.js-optimizer-node': function(tech, sourceNode, bundleNode) {
+        return this.createBorschikOptimizerNode('js', sourceNode, bundleNode);
+    },
 
     'create-css-optimizer-node': function(tech, sourceNode, bundleNode) {
         return this.createBorschikOptimizerNode('css-fast', sourceNode, bundleNode);

--- a/lib/techs/node.js.js
+++ b/lib/techs/node.js.js
@@ -1,0 +1,41 @@
+var INHERIT = require('inherit'),
+    Tech = require('../tech').Tech,
+    Template = require('../template'),
+    bemUtil = require('../util');
+
+exports.Tech = INHERIT(Tech, {
+	
+	getTechName: function() {
+		return 'node.js';
+	},
+
+    getBuildResultChunk: function(relPath, path, suffix) {
+        return '/*borschik:include:' + relPath + '*/;\n';
+    },
+
+	storeBuildResult: function(path, suffix, res) {
+			myres = "var INHERIT = require('inherit')\n  , BLOCKDATA = require('../../plugins/bemdata.js');\n"
+			+"\nvar db = module.parent.exports.db\n"
+			+"  , req = module.parent.exports.req\n"
+			+"  , res = module.parent.exports.res;\n\n"
+			+res
+            return bemUtil.writeFile(path, myres);
+        },
+
+    getCreateResult: function(path, suffix, vars) {
+
+        vars.Selector = 'exports[\'' + vars.BlockName +
+            (vars.ElemName? '__' + vars.ElemName : '') +
+            (vars.ModVal? '_' + vars.ModName + '_' + vars.ModVal : '') +
+            '\'] = INHERIT( BLOCKDATA, {\n\n},';
+
+        return Template.process([
+            '{{bemSelector}}',
+            '{',
+            '});'],
+            vars);
+
+    }
+},{
+	techname: 'node.js'
+});


### PR DESCRIPTION
This technology makes possible to make node.js/express backend using BEM. You create blocks with technology `node.js`.
Every block creating oblect `exports[blockname] = Object`. `Object` is inherited from class definition which you make in separate file.
You could use `db`, `req` & `res` variables in these declarations which correspond to db instance and request/response objects. 
After `bem build` you could `require` your file from the express `route` files like this:

``` js
/*
 * Module requirements
 */

var inherit = require('inherit')
  , Server = require('mongodb').Server
  , Db = require('mongodb').Db
  , Connection = require('mongodb').Connection;

exports.db = db = new Db('ruskline', new Server("127.0.0.1", 27017, {}), {});

/*
 * GET home page.
 */

exports.index = function(req, res){

    exports.req = req;
    exports.res = res;
    var context = require('../pages/lenta/lenta.node.js');

    res.render('lenta/lenta', context, function(err, str) {
        if(err) throw err;
        res.send(str);
    });
};
```
