### PR TITLE
Refactor Tech: introduce getBuildSuffixesMap()

### DIFF
--- a/lib/nodes/build.js
+++ b/lib/nodes/build.js
@@ -233,7 +233,7 @@ registry.decl(BemBuildNodeName, GeneratedFileNode, {
     lastModified: function() {
 
         return Q.all(this.tech
-            .getPaths(PATH.resolve(this.root, this.output), this.tech.getBuildSuffixes())
+            .getPaths(PATH.resolve(this.root, this.output), Object.keys(this.tech.getBuildSuffixesMap()))
             .map(function(path) {
 
                 return QFS.lastModified(path)
@@ -254,7 +254,7 @@ registry.decl(BemBuildNodeName, GeneratedFileNode, {
 
         var _this = this;
         return Q.all(this.tech
-            .getPaths(PATH.resolve(this.root, this.output), this.tech.getBuildSuffixes())
+            .getPaths(PATH.resolve(this.root, this.output), Object.keys(this.tech.getBuildSuffixesMap()))
             .map(function(path) {
 
                 return QFS.remove(path)
@@ -277,7 +277,7 @@ registry.decl(BemBuildNodeName, GeneratedFileNode, {
     },
 
     getFiles: function() {
-        return this.tech.getPaths(this.output, this.tech.getBuildSuffixes());
+        return this.tech.getPaths(this.output, Object.keys(this.tech.getBuildSuffixesMap()));
     },
 
     getDependencies: function() {

--- a/lib/tech.js
+++ b/lib/tech.js
@@ -476,13 +476,17 @@ var Q = require('qq'),
          * @returns {Promise * String}  Promise for build result.
          */
         getBuildResult: function(prefixes, suffix, outputDir, outputName) {
+
             var _this = this;
-            return Q.when(this.filterPrefixes(prefixes, [suffix]), function(paths) {
+            return Q.when(this.filterPrefixes(prefixes, this.getBuildSuffixesMap()[suffix]), function(paths) {
+
                 return Q.all(paths.map(function(path) {
                     return _this.getBuildResultChunk(
                         PATH.relative(outputDir, path), path, suffix);
                 }));
+
             });
+
         },
 
         /**
@@ -495,14 +499,17 @@ var Q = require('qq'),
          * @returns {Promise * Object}  Promise for build results object.
          */
         getBuildResults: function(prefixes, outputDir, outputName) {
+
             var _this = this,
                 res = {};
 
-            this.getBuildSuffixes().forEach(function(suffix) {
-                res[suffix] = _this.getBuildResult(prefixes, suffix, outputDir, outputName);
-            });
+            Object.keys(this.getBuildSuffixesMap())
+                .forEach(function(suffix) {
+                    res[suffix] = _this.getBuildResult(prefixes, suffix, outputDir, outputName);
+                });
 
             return Q.shallow(res);
+
         },
 
         /**
@@ -527,12 +534,18 @@ var Q = require('qq'),
          * @return {Promise * Undefined}
          */
         storeBuildResults: function(prefix, res) {
+
             var _this = this;
             return Q.when(res, function(res) {
-                return Q.all(_this.getBuildSuffixes().map(function(suffix) {
-                    return _this.storeBuildResult(_this.getPath(prefix, suffix), suffix, res[suffix]);
-                })).get(0);
+
+                return Q.all(Object.keys(_this.getBuildSuffixesMap())
+                    .map(function(suffix) {
+                        return _this.storeBuildResult(_this.getPath(prefix, suffix), suffix, res[suffix]);
+                    }))
+                    .get(0);
+
             });
+
         },
 
         /**
@@ -573,6 +586,21 @@ var Q = require('qq'),
          */
         getBuildSuffixes: function() {
             return this.getSuffixes();
+        },
+
+        /**
+         * Return map of tech suffixes to use on bem build.
+         *
+         * @return {Object}
+         */
+        getBuildSuffixesMap: function() {
+
+            return this.getBuildSuffixes()
+                .reduce(function(map, tech) {
+                    map[tech] = [tech];
+                    return map;
+                }, {});
+
         },
 
         /**


### PR DESCRIPTION
Introduce `getBuildSuffixesMap()` that will return object like (keys are build suffixes and values are arrays of create suffixes):

``` js
{
  'bemhtml.js': ['bemhtml']
}
```

or

``` js
{
  'css': ['css', 'ie.css']
}
```

And use this method in `getBuildResults()` and `bem make` code.

Also need to provide default implementation of `getBuildSuffixesMap()` for the backwards compatibility.

This will simplify writing of non-standart tech modules.
