### PR TITLE
SvnLibraryNode: Ability to map checkout paths to custom directories

### DIFF
--- a/lib/nodes/lib.js
+++ b/lib/nodes/lib.js
@@ -208,12 +208,12 @@ registry.decl(ScmLibraryNodeName, LibraryNodeName, /** @lends ScmLibraryNode.pro
      * @param {String} o.root      Project root path.
      * @param {String} o.target    Library path.
      * @param {String} o.url       Repository URL.
-     * @param {String[]} [o.paths=['']]  Paths to checkout.
+     * @param {Object|String[]} [o.paths={'': ''}]  Paths to checkout.
      */
     __constructor: function(o) {
         this.__base(o);
         this.url = o.url;
-        this.paths = [''];
+        this.paths = {'': ''};
         this.timeout = typeof o.timeout !== 'undefined'? Number(o.timeout) : SCM_VALIDITY_TIMEOUT;
     },
 
@@ -249,7 +249,7 @@ registry.decl(ScmLibraryNodeName, LibraryNodeName, /** @lends ScmLibraryNode.pro
     },
 
     /**
-     * Checkput or update single repository path.
+     * Checkout or update single repository path.
      *
      * @param {String} path  Repository path to checkout / update.
      * @param {String} mappedTo Overrides destination directory if specified.
@@ -293,16 +293,9 @@ registry.decl(ScmLibraryNodeName, LibraryNodeName, /** @lends ScmLibraryNode.pro
      * @return {Promise * Undefined}
      */
     getLibraryContent: function() {
-        var paths = this.paths,
-            hash = false;
 
-        if (!Array.isArray(this.paths)) {
-            paths = Object.keys(paths);
-            hash = true;
-        }
-
-        return Q.all(paths.map(function(path) {
-            return this.updatePath(path, hash? this.paths[path]: undefined);
+        return Q.all(Object.keys(this.paths).map(function(source) {
+            return this.updatePath(source, this.paths[source]);
         }, this));
 
     }
@@ -363,13 +356,22 @@ registry.decl(SvnLibraryNodeName, ScmLibraryNodeName, /** @lends SvnLibraryNode.
      * @param {String} o.root      Project root path.
      * @param {String} o.target    Library path.
      * @param {String} o.url       Repository URL.
-     * @param {String[]} [o.paths=['']]  Paths to checkout.
+     * @param {Object|String[]} [o.paths={'': ''}]  Paths to checkout.
      * @param {String} [o.revision='HEAD']  Revision to checkout.
      */
     __constructor: function(o) {
+
         this.__base(o);
-        this.paths = Array.isArray(o.paths)? o.paths : o.paths || [''];
+
+        this.paths = Array.isArray(o.paths)?
+            o.paths.reduce(function(hash, p) {
+                    hash[p] = p;
+                    return hash;
+                }, {}) :
+            o.paths || {'': ''};
+
         this.revision = o.revision || 'HEAD';
+
     },
 
     /**
@@ -384,35 +386,29 @@ registry.decl(SvnLibraryNodeName, ScmLibraryNodeName, /** @lends SvnLibraryNode.
     isValid: function() {
 
         var _this = this,
-            base = this.__base(),
-            paths = this.paths,
-            hash = false;
+            base = this.__base();
 
         if (this.revision === 'HEAD') return base;
 
-        if (!Array.isArray(paths)) {
-            paths = Object.keys(paths);
-            hash = true;
-        }
+        return Q.all(Object.keys(this.paths).map(function(source) {
 
-        return Q.all(paths.map(function(path) {
-            var p = (hash? _this.paths[path]: path) || path;
-            return QFS.exists(PATH.resolve(_this.root, _this.target, p))
-                .then(function(exists) {
-                    return exists && _this.getInfo(p)
-                        .then(function(info) {
-                            return String(info.revision) === String(_this.revision);
-                        });
-                });
+                var p = _this.paths[source];
+                return QFS.exists(PATH.resolve(_this.root, _this.target, p))
+                    .then(function(exists) {
+                        return exists && _this.getInfo(p)
+                            .then(function(info) {
+                                return String(info.revision) === String(_this.revision);
+                            });
+                    });
 
-        }))
-        .then(function(checks) {
+            }))
+            .then(function(checks) {
 
-            return checks.reduce(function(cur, prev) {
-                return cur && prev;
-            }, true) || base;
+                return checks.reduce(function(cur, prev) {
+                    return cur && prev;
+                }, true) || base;
 
-        });
+            });
 
     },
 

--- a/lib/nodes/lib.js
+++ b/lib/nodes/lib.js
@@ -252,12 +252,13 @@ registry.decl(ScmLibraryNodeName, LibraryNodeName, /** @lends ScmLibraryNode.pro
      * Checkput or update single repository path.
      *
      * @param {String} path  Repository path to checkout / update.
+     * @param {String} mappedTo Overrides destination directory if specified.
      * @return {Promise * Undefined}
      */
-    updatePath: function(path) {
+    updatePath: function(path, mappedTo) {
 
         var _this = this,
-            target = PATH.resolve(this.root, this.target, path),
+            target = PATH.resolve(this.root, this.target, mappedTo || path),
             repo = joinUrlPath(this.url, path);
 
         return QFS.exists(target)
@@ -292,9 +293,16 @@ registry.decl(ScmLibraryNodeName, LibraryNodeName, /** @lends ScmLibraryNode.pro
      * @return {Promise * Undefined}
      */
     getLibraryContent: function() {
+        var paths = this.paths,
+            hash = false;
 
-        return Q.all(this.paths.map(function(path) {
-            return this.updatePath(path);
+        if (!Array.isArray(this.paths)) {
+            paths = Object.keys(paths);
+            hash = true;
+        }
+
+        return Q.all(paths.map(function(path) {
+            return this.updatePath(path, hash? this.paths[path]: undefined);
         }, this));
 
     }
@@ -360,7 +368,7 @@ registry.decl(SvnLibraryNodeName, ScmLibraryNodeName, /** @lends SvnLibraryNode.
      */
     __constructor: function(o) {
         this.__base(o);
-        this.paths = Array.isArray(o.paths)? o.paths : [o.paths || ''];
+        this.paths = Array.isArray(o.paths)? o.paths : o.paths || [''];
         this.revision = o.revision || 'HEAD';
     },
 
@@ -376,27 +384,35 @@ registry.decl(SvnLibraryNodeName, ScmLibraryNodeName, /** @lends SvnLibraryNode.
     isValid: function() {
 
         var _this = this,
-            base = this.__base();
+            base = this.__base(),
+            paths = this.paths,
+            hash = false;
 
         if (this.revision === 'HEAD') return base;
 
-        return Q.all(this.paths.map(function(path) {
-                return QFS.exists(PATH.resolve(_this.root, _this.target, path))
-                    .then(function(exists) {
-                        return exists && _this.getInfo(path)
-                            .then(function(info) {
-                                return String(info.revision) === String(_this.revision);
-                            });
+        if (!Array.isArray(paths)) {
+            paths = Object.keys(paths);
+            hash = true;
+        }
+
+        return Q.all(paths.map(function(path) {
+            var p = (hash? _this.paths[path]: path) || path;
+            return QFS.exists(PATH.resolve(_this.root, _this.target, p))
+                .then(function(exists) {
+                    return exists && _this.getInfo(p)
+                        .then(function(info) {
+                            return String(info.revision) === String(_this.revision);
+                        });
                 });
 
-            }))
-            .then(function(checks) {
+        }))
+        .then(function(checks) {
 
-                return checks.reduce(function(cur, prev) {
-                    return cur && prev;
-                }, true) || base;
+            return checks.reduce(function(cur, prev) {
+                return cur && prev;
+            }, true) || base;
 
-            });
+        });
 
     },
 


### PR DESCRIPTION
It is needed to maintain compatibility of legacy libs with new project layout.

Example:

``` js
{
    'lego': {
        type: 'svn',
        url: 'svn+ssh://svn.yandex.ru/lego/versions/2.10',
        paths: {
            'blocks-common': 'common.blocks',
            'blocks-desktop': 'desktop.blocks',
            'tools': ''
        }
    }
}
```

That config should checkout `blocks-common` into `lego/common.blocks`, `blocks-desktop` into `lego/desktop.blocks` and `tools` into `lego/tools`.
