### PR TITLE
bem create: Allow techs specifying using dot notation

### DIFF
--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -106,6 +106,12 @@ module.exports = function() {
                         }
                     }
 
+                    // Try to get techs specified using dot notation
+                    if (partial.tech) {
+                        partial.techs = partial.tech.split(',');
+                        delete partial.tech;
+                    }
+
                     prev = bemUtil.extend(item, partial);
                     if (!prev.block) return;
 
@@ -114,16 +120,27 @@ module.exports = function() {
 
                 techs = context.getDefaultTechs();
 
-            if (!techs.length) return Q.reject('You should specify techs to create using --force-tech, -T or --add-tech, -t options');
-
             opts.block && opts.block.forEach(eachBlock);
             args.entities && args.entities.forEach(eachEntity);
 
             return Q.all(items.map(function(item) {
-                    return Q.all(techs.map(function(t) {
-                        return context.getTech(t).createByDecl(item, opts.level, addOpts);
-                    })).get(0);
-                })).get(0);
+
+                    var t = [].concat(techs).concat(item.techs || []);
+
+                    if (!t.length) {
+                        return Q.reject(['Can\'t create BEM entity: ', bemUtil.bemKey(item), '\n',
+                            'You should specify techs to create using --force-tech, -T ',
+                            'or --add-tech, -t options or using dot notaion, ',
+                            'e.g. block.css'].join(''));
+                    }
+
+                    return Q.all(t.map(function(t) {
+                            return context.getTech(t).createByDecl(item, opts.level, addOpts);
+                        }))
+                        .get(0);
+
+                }))
+                .get(0);
 
         });
 


### PR DESCRIPTION
Example: `block__elem.css,js`
