### PR TITLE
Add socket-only option to make bem server listen only unix socket (close...

### DIFF
--- a/lib/commands/server.js
+++ b/lib/commands/server.js
@@ -37,10 +37,21 @@ module.exports = function() {
             .name('port').short('p').long('port')
             .title('tcp port to listen on, default: ' + DEFAULT_PORT)
             .def(DEFAULT_PORT)
+            .val(function(val) {
+                if (!isNaN(val)) return val;
+
+                LOGGER.error('tcp port must be a number');
+                process.exit();
+            })
             .end()
         .opt()
             .name('socket').long('socket')
             .title('listen on unix socket in addition to net socket')
+            .flag()
+            .end()
+        .opt()
+            .name('socketOnly').long('socket-only')
+            .title('listen on unix socket (net socket will not be used)')
             .flag()
             .end()
         .opt()

--- a/lib/server.js
+++ b/lib/server.js
@@ -15,9 +15,9 @@ exports.Server = INHERIT(Server, {
 
     startServer: function(requestHandler) {
         var _this = this,
-            started = this.__base(requestHandler);
+            started = this.opts.socketOnly? []: this.__base(requestHandler);
 
-        if (!_this.opts.socket) return started;
+        if (!(_this.opts.socket || _this.opts.socketOnly)) return started;
 
         // Start server on unix socket
         var sockServer = QHTTP.Server(requestHandler);


### PR DESCRIPTION
- socket-only added
- added a check for specified tcp port value to be a number
