### PR TITLE
Ability to specify source techs for BundlesLevelNode

### DIFF
--- a/lib/nodes/level.js
+++ b/lib/nodes/level.js
@@ -204,6 +204,12 @@ registry.decl(BundlesLevelNodeName, LevelNodeName, {
         return false;
     },
 
+    /**
+     * Return all possible source techs for bundle.
+     *
+     * @public
+     * @return {String[]}
+     */
     getBundleSourceTechs: function() {
         return ['bemjson.js', 'bemdecl.js'];
     },

--- a/lib/nodes/level.js
+++ b/lib/nodes/level.js
@@ -273,7 +273,7 @@ registry.decl(BundlesLevelNodeName, LevelNodeName, {
                         if (type === 'block' && item.block === this.mergedBundleName()) return false;
 
                         // build only blocks and elems that have file in `bundleSourceTechs` techs
-                        return ~['block', 'elem'].indexOf(type) && ~this.getBundleSourceTechs.indexOf(item.tech);
+                        return ~['block', 'elem'].indexOf(type) && ~this.getBundleSourceTechs().indexOf(item.tech);
 
                     }, this),
                 U.bemKey),

--- a/lib/nodes/level.js
+++ b/lib/nodes/level.js
@@ -48,10 +48,6 @@ registry.decl(LevelNodeName, MagicNode, {
 
     },
 
-    getSourceTechs: function() {
-        return ['bemjson.js', 'bemdecl.js'];
-    },
-
     alterArch: function() {
 
         var ctx = this.ctx;
@@ -208,6 +204,10 @@ registry.decl(BundlesLevelNodeName, LevelNodeName, {
         return false;
     },
 
+    getBundleSourceTechs: function() {
+        return ['bemjson.js', 'bemdecl.js'];
+    },
+
     /**
      * Overriden.
      *
@@ -262,8 +262,6 @@ registry.decl(BundlesLevelNodeName, LevelNodeName, {
      */
     scanLevelItems: function() {
 
-        var sourceTechs = this.getSourceTechs();
-
         return _.uniq(
             _.sortBy(
                 this.level.getItemsByIntrospection()
@@ -274,8 +272,8 @@ registry.decl(BundlesLevelNodeName, LevelNodeName, {
                         // filter out merged bundle, it will be configured later
                         if (type === 'block' && item.block === this.mergedBundleName()) return false;
 
-                        // build only blocks and elems that have file in source techs
-                        return ~['block', 'elem'].indexOf(type) && ~sourceTechs.indexOf(item.tech);
+                        // build only blocks and elems that have file in `bundleSourceTechs` techs
+                        return ~['block', 'elem'].indexOf(type) && ~this.getBundleSourceTechs.indexOf(item.tech);
 
                     }, this),
                 U.bemKey),

--- a/lib/nodes/level.js
+++ b/lib/nodes/level.js
@@ -48,6 +48,10 @@ registry.decl(LevelNodeName, MagicNode, {
 
     },
 
+    getSourceTechs: function() {
+        return ['bemjson.js', 'bemdecl.js'];
+    },
+
     alterArch: function() {
 
         var ctx = this.ctx;
@@ -258,6 +262,8 @@ registry.decl(BundlesLevelNodeName, LevelNodeName, {
      */
     scanLevelItems: function() {
 
+        var sourceTechs = this.getSourceTechs();
+
         return _.uniq(
             _.sortBy(
                 this.level.getItemsByIntrospection()
@@ -268,8 +274,8 @@ registry.decl(BundlesLevelNodeName, LevelNodeName, {
                         // filter out merged bundle, it will be configured later
                         if (type === 'block' && item.block === this.mergedBundleName()) return false;
 
-                        // build only blocks and elems that have file in bemjson.js or bemdecl.js techs
-                        return ~['block', 'elem'].indexOf(type) && ~['bemjson.js', 'bemdecl.js'].indexOf(item.tech);
+                        // build only blocks and elems that have file in source techs
+                        return ~['block', 'elem'].indexOf(type) && ~sourceTechs.indexOf(item.tech);
 
                     }, this),
                 U.bemKey),


### PR DESCRIPTION
Adds the ability to specify a different from bemjson.js technology to build bemdecl.js

make.js

``` JavaScript
MAKE.decl('BundlesLevelNode', {
    getBundleSourceTechs: function () {
         return ['xml', 'bemdecl.js'];
    }
});
```

It's much more convenient than:

``` JavaScript
MAKE.decl('BundlesLevelNode', {

    /**
     * Overriden.
     *
     * Filters out merged bundle name (takes place when merged
     * bundle name directory exists on the file system).
     *
     * @return {Object[]}
     */
    scanLevelItems: function () {

        return _.uniq(
            _.sortBy(
                this.level.getItemsByIntrospection()
                    .filter(function (item) {

                        var type = U.bemType(item);

                        // filter out merged bundle, it will be configured later
                        if (type === 'block' && item.block === this.mergedBundleName()) return false;

                        // build only blocks and elems that have file in xml or bemdecl.js techs
                        return ~['block', 'elem'].indexOf(type) && ~['xml', 'bemdecl.js'].indexOf(item.tech);

                    }, this),
                U.bemKey),
            true,
            U.bemKey);

    }

});
```
