### PR TITLE
GitLibraryNode: Возможность переопределять remote name для гитовой библиотеки

### DIFF
--- a/lib/nodes/lib.js
+++ b/lib/nodes/lib.js
@@ -327,19 +327,23 @@ registry.decl(GitLibraryNodeName, ScmLibraryNodeName, /** @lends GitLibraryNode.
      * @param {String[]} [o.paths=['']]  Paths to checkout.
      * @param {String} [o.treeish]  Treeish (commit hash or tag) to checkout.
      * @param {String} [o.branch='master'] Branch to checkout.
+     * @param {String} [o.origin='upstream'] Remote name origin.
      */
     __constructor: function(o) {
         this.__base(o);
         this.treeish = o.treeish;
         this.branch = o.branch || 'master';
+        this.origin = o.origin || 'upstream';
     },
 
     getInitialCheckoutCmd: function(url, target) {
-        return UTIL.format('git clone --progress %s %s && cd %s && git checkout %s', url, target, target, this.treeish || this.branch);
+        return UTIL.format('git clone --progress --origin %s %s %s && cd %s && git checkout %s',
+                this.origin, url, target, target, this.treeish || this.branch);
     },
 
     getUpdateCmd: function(url, target) {
-        return UTIL.format('cd %s && git fetch origin && git reset --hard %s', target, this.treeish || 'origin/' + this.branch);
+        return UTIL.format('cd %s && git fetch %s && git reset --hard %s',
+                target, this.origin, this.treeish || this.origin + '/' + this.branch);
     }
 
 });


### PR DESCRIPTION
См. #355 

По умолчанию клонируем библиотеки с `--origin upstream`. Это, как минимум, предотвратит случайное выполнение `git reset --hard` для кода проекта в большенстве случаев. Поскольку, если директория библиотеки (еще) не является гит-репозиторием, «обновление скорее всего упадет» на `git fetch upstream`.
