### PR TITLE
Don't add braces in generated sass files

### DIFF
--- a/lib/techs/sass.js
+++ b/lib/techs/sass.js
@@ -1,10 +1,22 @@
 var INHERIT = require('inherit'),
+    Template = require('../template'),
     CssTech = require('./css').Tech;
 
 exports.Tech = INHERIT(CssTech, {
 
     getBuildResultChunk: function(relPath, path, suffix) {
         return '@import ' + relPath + '\n';
+    },
+    
+    getCreateResult: function(path, suffix, vars) {
+
+        vars.Selector = '.' + vars.BlockName +
+            (vars.ElemName? '__' + vars.ElemName : '') +
+            (vars.ModVal? '_' + vars.ModName + '_' + vars.ModVal : '');
+
+        return Template.process(['{{bemSelector}}'],
+            vars);
+
     }
 
 });


### PR DESCRIPTION
Braces (`{...}`) in generated `*.sass` files brakes sass syntax. SASS doesn't need it.
I redefine inhereted from css tech `getCreateResult` function to not add this braces.
