### PR TITLE
Fix for "Coud not call for method of undefined" when using nodes from API

### DIFF
--- a/lib/nodes/block.js
+++ b/lib/nodes/block.js
@@ -1,7 +1,7 @@
 var INHERIT = require('inherit'),
     PATH = require('../path'),
     U = require('../util'),
-    createLevel = require('../index').createLevel,
+    createLevel = require('../level').createLevel,
 
     registry = require('../nodesregistry'),
     MagicNode = require('./magic').MagicNodeName,


### PR DESCRIPTION
\cc @scf2k 

Такое уже чинили как-то, но в другом узле. Теперь в `nodes/block` «нашлось»
