### PR TITLE
Creating parent directory for SymlinkLibraryNode if one doesn't exists yet

### DIFF
--- a/lib/nodes/lib.js
+++ b/lib/nodes/lib.js
@@ -184,6 +184,21 @@ registry.decl(SymlinkLibraryNodeName, LibraryNodeName, /** @lends SymlinkLibrary
 
             })
             .then(function() {
+
+                var parent = PATH.dirname(_this.getPath());
+                return QFS.exists(parent)
+                    .then(function(exists) {
+
+                        if(!exists) {
+                            LOGGER.verbose("SymlinkLibraryNode: Creating parent directory for target '%s'",
+                                _this.getPath());
+                            return QFS.makeTree(parent);
+                        }
+
+                    });
+
+            })
+            .then(function() {
                 return QFS.symbolicLink(_this.getPath(), _this.relative);
             });
 


### PR DESCRIPTION
See #342 for details

\cc @scf2k 
