### PR TITLE
Cross-domain @font-face support in Firefox.

### DIFF
--- a/lib/base-server.js
+++ b/lib/base-server.js
@@ -270,6 +270,9 @@ exports.Server = INHERIT({
             response.status = 200;
             response.charset = 'binary';
             response.headers = { 'content-type': MIME.lookup(path) };
+            if (path.match(/\.(?:ttf|ttc|otf|eot|woff|font.css)$/)) {
+                response.headers["Access-Control-Allow-Origin"] = "*";
+            }
             response.body = QFS.open(path);
 
             return response;

--- a/lib/base-server.js
+++ b/lib/base-server.js
@@ -270,7 +270,7 @@ exports.Server = INHERIT({
             response.status = 200;
             response.charset = 'binary';
             response.headers = { 'content-type': MIME.lookup(path) };
-            if (path.match(/\.(?:ttf|ttc|otf|eot|woff|font.css)$/)) {
+            if (path.match(/\.(?:ttf|ttc|otf|eot|woff|font.css)$/i)) {
                 response.headers["Access-Control-Allow-Origin"] = "*";
             }
             response.body = QFS.open(path);


### PR DESCRIPTION
Запускаем bem server и приложение на разных доменах. В Firefox не отображаются подгружаемые шрифты. Сабж это фиксит:

Firefox (which supports @font-face from v3.5) does not allow cross-domain fonts
by default. This means the font must be served up from the same domain (and
sub-domain) unless you can add an “Access-Control-Allow-Origin” header to the
font.

See https://developer.mozilla.org/ru/docs/HTTP/Access_control_CORS
