### PR TITLE
Ability to specify source techs for BundlesLevelNode (master branch)

### DIFF
--- a/lib/nodes/level.js
+++ b/lib/nodes/level.js
@@ -210,6 +210,16 @@ registry.decl(BundlesLevelNodeName, LevelNodeName, {
     },
 
     /**
+     * Return all possible source techs for bundle.
+     *
+     * @public
+     * @return {String[]}
+     */
+    getBundleSourceTechs: function() {
+        return ['bemjson.js', 'bemdecl.js'];
+    },
+
+    /**
      * Overriden.
      *
      * After execution of the base method adds a MergedBundle node in the case it's enabled.
@@ -273,8 +283,8 @@ registry.decl(BundlesLevelNodeName, LevelNodeName, {
                         // filter out merged bundle, it will be configured later
                         if (type === 'block' && item.block === this.mergedBundleName()) return false;
 
-                        // build only blocks and elems that have file in bemjson.js or bemdecl.js techs
-                        return ~['block', 'elem'].indexOf(type) && ~['bemjson.js', 'bemdecl.js'].indexOf(item.tech);
+                        // build only blocks and elems that have file in source techs
+                        return ~['block', 'elem'].indexOf(type) && ~this.getBundleSourceTechs().indexOf(item.tech);
 
                     }, this),
                 U.bemKey),


### PR DESCRIPTION
This pull request adds changes from #349 (dev branch) to master branch.

Adds the ability to specify a different from bemjson.js technology to build bemdecl.js

make.js

``` JavaScript
MAKE.decl('BundlesLevelNode', {
    getBundleSourceTechs: function () {
         return ['xml', 'bemdecl.js'];
    }
});
```
