### PR TITLE
Level#scanFiles returns "undefined" for some suffixes

### DIFF
--- a/lib/level.js
+++ b/lib/level.js
@@ -875,8 +875,8 @@ var Level = exports.Level = INHERIT(/** @lends Level.prototype */{
             },
             items = {
                 push: function(file, item) {
-                    file.suffix = item.suffix[0] === '.'?item.suffix.substr(1):item.suffix;
-                    (list[file.suffix] || (list[file.suffix] = [])).push(file);
+                    var suffix = file.suffix = item.suffix[0] === '.'?item.suffix.substr(1):item.suffix;
+                    (list[suffix] || (list[suffix] = [])).push(file);
                     flat.push(item);
 
                     var block = blocks[item.block] || (blocks[item.block] = {elems: {}, mods: {}, files: {}});
@@ -893,7 +893,7 @@ var Level = exports.Level = INHERIT(/** @lends Level.prototype */{
                         if (item.val) block = block.vals[item.val] || (block.vals[item.val] = {files: {}});
                     }
 
-                    (block.files[file.suffix] || (block.files[file.suffix] = [])).push(file);
+                    (block.files[suffix] || (block.files[suffix] = [])).push(file);
                 }
             };
 


### PR DESCRIPTION
\cc @scf2k 

Example for bem-core: after `common.blocks` level's introspection there are some strange records in `.bem/cache/common.blocks/files.json`:

```
...
"undefined"                                : ["i-bem.examples", "i-bem.test.bemhtml", "page.examples"],
...
```
