### PR TITLE
Weak Suffixes Map

### DIFF
--- a/lib/tech/v2.js
+++ b/lib/tech/v2.js
@@ -392,7 +392,11 @@ var Q = require('q'),
         getBuildPaths: function(decl, levels) {
             var _this = this,
                 res = {},
-                suffixesMap = this.getSuffixesMap();
+                suffixesStrong = this.getSuffixesMap(),
+                suffixesWeak = this.getWeakSuffixesMap(),
+                suffixesMap,
+                depTech,
+                uniq = {};
 
             return Q.when(decl, function(decl) {
 
@@ -407,9 +411,18 @@ var Q = require('q'),
                         if (decl.deps) for(var d = 0; d < decl.deps.length; d++) {
                             var dep = decl.deps[d];
 
+                            if (dep.tech) {
+                                var depTech = _this.context.getTech(dep.tech);
+                                suffixesMap = suffixesWeak;
+                            } else {
+                                var depTech = _this;
+                                suffixesMap = suffixesStrong;
+                            }
+                            
+
                             for(var l = 0; l < levels.length; l++) {
                                 var level = levels[l],
-                                    files = level.getFileByObjIfExists(dep, _this);
+                                    files = level.getFileByObjIfExists(dep, depTech);
 
                                 if (files) {
                                     for(var i = 0; i < files.length; i++) {
@@ -419,7 +432,13 @@ var Q = require('q'),
                                         if (buildSuffixes) {
                                             for(var bs = 0; bs < buildSuffixes.length; bs++) {
                                                 var buildSuffix = buildSuffixes[bs];
-                                                (res[buildSuffix] || (res[buildSuffix] = [])).push(file);
+                                                
+                                                !uniq[buildSuffix] && (uniq[buildSuffix] = {});
+                                                
+                                                if (!(file.absPath in uniq[buildSuffix])) {
+                                                    uniq[buildSuffix][file.absPath] = true;
+                                                    (res[buildSuffix] || (res[buildSuffix] = [])).push(file);
+                                                }
                                             }
                                         }
                                     }

--- a/lib/tech/v2.js
+++ b/lib/tech/v2.js
@@ -412,10 +412,10 @@ var Q = require('q'),
                             var dep = decl.deps[d];
 
                             if (dep.tech) {
-                                var depTech = _this.context.getTech(dep.tech);
+                                depTech = _this.context.getTech(dep.tech);
                                 suffixesMap = suffixesWeak;
                             } else {
-                                var depTech = _this;
+                                depTech = _this;
                                 suffixesMap = suffixesStrong;
                             }
                             

--- a/lib/tech/v2.js
+++ b/lib/tech/v2.js
@@ -524,6 +524,23 @@ var Q = require('q'),
             return res;
         },
 
+        getWeakBuildSuffixesMap:function(){
+            return this.getBuildSuffixesMap();
+        },
+
+        getWeakSuffixesMap:function(){
+            var buildMap = this.getWeakBuildSuffixesMap(),
+                srcMap = {};
+
+            Object.keys(buildMap).forEach(function(buildSuffix) {
+                buildMap[buildSuffix].forEach(function(srcSuffix) {
+                    (srcMap[srcSuffix] || (srcMap[srcSuffix] = [])).push(buildSuffix);
+                }, this);
+            }, this);
+
+            return srcMap;
+        },
+
         getSuffixesMap: function() {
             var buildMap = this.getBuildSuffixesMap(),
                 srcMap = {};

--- a/lib/tech/v2.js
+++ b/lib/tech/v2.js
@@ -359,7 +359,7 @@ var Q = require('q'),
 
             file = PATH.join(
                 root, '.bem', 'cache',
-                PATH.relative(root, file) + '.meta.js');
+                PATH.relative(root, file) + '~' + this.getTechName() + '.meta.js');
 
             return bemUtil
                 .readFile(file)
@@ -381,7 +381,7 @@ var Q = require('q'),
             var root = this.context.opts.root || '';
             file = PATH.join(
                 root, '.bem', 'cache',
-                PATH.relative(root, file) + '.meta.js');
+                PATH.relative(root, file) + '~' + this.getTechName() + '.meta.js');
 
             return Q.when(bemUtil.mkdirs(PATH.dirname(file)))
                 .then(function() {

--- a/lib/techs/v2/deps.js.js
+++ b/lib/techs/v2/deps.js.js
@@ -568,14 +568,6 @@ var Deps = exports.Deps = INHERIT(/** @lends Deps.prototype */{
      * @returns {Array}
      */
     filter: function(fn) {
-        var res = [];
-        this.forEach(function(item, ctxItem) {
-            if (fn.call(this, item, ctxItem)) res.push(item);
-        });
-        return res;
-    },
-
-    filter2: function(fn) {
         var _this = this, uniq = {}, res = [];
         _filter();
         return res;

--- a/lib/techs/v2/deps.js.js
+++ b/lib/techs/v2/deps.js.js
@@ -19,7 +19,7 @@ exports.techMixin = {
 
     getBuildSuffixesMap: function() {
         return {
-            'deps.js': 'deps.js'
+            'deps.js': ['deps.js']
         };
     },
 
@@ -573,6 +573,40 @@ var Deps = exports.Deps = INHERIT(/** @lends Deps.prototype */{
             if (fn.call(this, item, ctxItem)) res.push(item);
         });
         return res;
+    },
+
+    filter2: function(fn) {
+        var _this = this, uniq = {}, res = []
+        _filter();
+        return res;
+        
+        function _filter(itemsByOrder,ctx){
+            (itemsByOrder||_this.items[''].shouldDeps).forEach(function(item){
+                if(item = _this.items[item]){
+                    var newCtx = ctx || item;
+                    var key = item.buildKey()
+                    if(uniq[key] === undefined){
+                        uniq[key] = 1;
+                        _filter(item.mustDeps,item)
+                        if(uniq[key] !== 2){
+                            var r = fn.call(_this,item,newCtx)
+                            if(r){
+                                uniq[key] = 2;
+                                res.push(item);
+                            }
+                        }
+                        _filter(item.shouldDeps,item);
+                    } else if(uniq[key] === 1){
+                        if(fn.call(_this,item,newCtx)){
+                            uniq[key] = 2;
+                            res.push(item);
+                        }
+                    } else if(uniq[key] === 2){
+                        // skip the item completely
+                    }
+                }
+            })
+        }
     },
 
     /**

--- a/lib/techs/v2/deps.js.js
+++ b/lib/techs/v2/deps.js.js
@@ -576,7 +576,7 @@ var Deps = exports.Deps = INHERIT(/** @lends Deps.prototype */{
     },
 
     filter2: function(fn) {
-        var _this = this, uniq = {}, res = []
+        var _this = this, uniq = {}, res = [];
         _filter();
         return res;
         
@@ -584,12 +584,12 @@ var Deps = exports.Deps = INHERIT(/** @lends Deps.prototype */{
             (itemsByOrder||_this.items[''].shouldDeps).forEach(function(item){
                 if(item = _this.items[item]){
                     var newCtx = ctx || item;
-                    var key = item.buildKey()
+                    var key = item.buildKey();
                     if(uniq[key] === undefined){
                         uniq[key] = 1;
-                        _filter(item.mustDeps,item)
+                        _filter(item.mustDeps,item);
                         if(uniq[key] !== 2){
-                            var r = fn.call(_this,item,newCtx)
+                            var r = fn.call(_this,item,newCtx);
                             if(r){
                                 uniq[key] = 2;
                                 res.push(item);
@@ -605,7 +605,7 @@ var Deps = exports.Deps = INHERIT(/** @lends Deps.prototype */{
                         // skip the item completely
                     }
                 }
-            })
+            });
         }
     },
 


### PR DESCRIPTION
Add ability to specify "weak" suffixes for technology.

Usual behavior for technology suffixes is considered to be strong-binding, i.e. when dependency item has no technology specified, any file that matches (item path + any suffix for building technology) is included in sources file list.

Another kind of behavior is added, which is considered to be weak-binding -- suffixes that are weak don't add files to source files list, unless technology matching the weak-suffix is explicitly specified in the dependency item.
