### PR TITLE
bemdecl.js: Traverse through all fields, not only `mix` and `content`.

### DIFF
--- a/lib/techs/v2/bemdecl.js.js
+++ b/lib/techs/v2/bemdecl.js.js
@@ -21,10 +21,15 @@ exports.techMixin = {
             throw e;
         }
 
+        return 'exports.blocks = ' +
+            JSON.stringify(this.buildBemdeclByBemjson(bemjson), null, 4) +
+            ';\n';
+    },
+
+    buildBemdeclByBemjson: function(bemjson) {
         var decl = [];
         iterateJson(bemjson, getBuilder(decl));
-
-        return 'exports.blocks = ' + JSON.stringify(bemUtil.mergeDecls([], decl), null, 4) + ';\n';
+        return bemUtil.mergeDecls([], decl);
     },
 
     storeCreateResult: function(path, suffix, res, force) {
@@ -85,7 +90,26 @@ function getBuilder(decl, block) {
                         }]
                     });
 
-        iterateJson([obj.mix, obj.content], getBuilder(decl, block));
+        var contents = [],
+            nonContentKeys = {
+                block: 1,
+                elem: 1,
+                mods: 1,
+                elemMods: 1,
+                bem: 1,
+                tag: 1,
+                attrs: 1,
+                cls: 1,
+                js: 1
+            },
+            k;
+
+        for(k in obj)
+            obj.hasOwnProperty(k) &&
+                !nonContentKeys.hasOwnProperty(k) &&
+                    contents.push(obj[k]);
+
+        iterateJson(contents, getBuilder(decl, block));
 
         block = oldBlock;
     };

--- a/test/bemdecl.js
+++ b/test/bemdecl.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var assert = require('chai').assert,
+    buildBemdeclByBemjson = require('..').require('./techs/v2/bemdecl.js.js').techMixin.buildBemdeclByBemjson;
+
+/**
+ * Mocha BDD interface.
+ */
+/** @name describe @function */
+/** @name it @function */
+/** @name before @function */
+/** @name after @function */
+/** @name beforeEach @function */
+/** @name afterEach @function */
+
+describe('BEMDECL', function() {
+    describe('buildBemdeclByBemjson:', function() {
+        it('should properly parse custom content fields', function() {
+            assert.deepEqual(
+                buildBemdeclByBemjson({
+                    block: 'b',
+                    bem: { block: 'bla4' },
+                    tag: { block: 'bla5' },
+                    attrs: { block: 'bla6' },
+                    cls: { block: 'bla7' },
+                    js: { block: 'bla8' },
+                    custom1: { block: 'b1' },
+                    custom2: {
+                        a1: { block: 'a1' },
+                        a2: { block: 'a2' }
+                    },
+                    mix: [ { block: 'c' } ],
+                    content: { block: 'd' }
+                }),
+                [
+                  { name: 'b' },
+                  { name: 'b1' },
+                  { name: 'a1' },
+                  { name: 'a2' },
+                  { name: 'c' },
+                  { name: 'd' }
+                ]
+            );
+        });
+    });
+});


### PR DESCRIPTION
close #423
