### PR TITLE
Don't use insight on CI builds

### DIFF
--- a/bin/bem
+++ b/bin/bem
@@ -15,7 +15,7 @@ Error.stackTraceLimit = Infinity;
 var insight = require('../lib/insight'),
     coa = require('../lib/coa');
 
-if (insight.optOut === undefined) {
+if (!process.env.CI && insight.optOut === undefined) {
     insight.track('first-run');
     insight.askPermission(null, run);
 } else {


### PR DESCRIPTION
bem-tools 1.0.0 on travis always fails because of insight permissions request. [Example](https://travis-ci.org/bem/bem-core/jobs/10972998).
The solution is to check `CI` enviroment variable to determine if we are running in continious integration enviroment.  Approach with checking `process.stdin.isTTY` didn't work - it's always `true` on travis.

We need to publish new release when this will be merged. This issue is blocking bem/bem-core#239 and bem/bem-components#188.

/cc @scf2k @arikon 
