### PR TITLE
Interactive coverage reporting, without pre-instrumenting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@
 .bem/cache
 node_modules/
 test-make-temp/
-lib-cov/
-coverage.html
+coverage/
 .DS_Store

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,7 +1,7 @@
 BEM = ./bin/bem
 BIN = ./node_modules/.bin
-MOCHA = $(BIN)/mocha
-JSCOV = $(BIN)/coverjs
+MOCHA = $(BIN)/_mocha
+ISTNBUL = $(BIN)/istanbul
 JSHINT = $(BIN)/jshint
 
 .PHONY: all
@@ -19,18 +19,13 @@ jshint:
 
 .PHONY: test
 test: jshint
-	$(MOCHA)
-
-.PHONY: lib-cov
-lib-cov:
-	-rm -rf lib-cov
-	$(JSCOV) --recursive --output lib-cov lib/*
+	$(ISTNBUL) test $(MOCHA)
 
 .PHONY: test-cover
-test-cover: lib-cov test
-	COVER=1 $(MOCHA) --reporter mocha-coverjs > coverage.html
+test-cover:
+	$(ISTNBUL) cover $(MOCHA)
 	@echo
-	@echo Open ./coverage.html file in your browser
+	@echo Open ./coverage/lcov-report/index.html file in your browser
 
 .PHONY: tests
 tests:

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require(process.env.COVER? './lib-cov/index' : './lib/index');
+module.exports = require('./lib/index');

--- a/lib/util.js
+++ b/lib/util.js
@@ -532,14 +532,12 @@ exports.arrayReverse = function(arr) {
 
 exports.getBemTechPath = function(name) {
 
-    var bemLib = process.env.COVER? 'bem/lib-cov/' : 'bem/lib/',
-        bemTechs = PATH.unixToOs(bemLib + 'techs'),
-        path = PATH.join(bemTechs, name);
+    var path = PATH.join('bem', 'lib', 'techs', name);
 
     if(exports.isRequireable(path + '.js')) return path + '.js';
     if(exports.isRequireable(path)) return path;
 
-    return PATH.unixToOs(bemLib + 'tech');
+    return PATH.unixToOs('bem/lib/tech');
 
 };
 

--- a/package.json
+++ b/package.json
@@ -46,15 +46,14 @@
   "devDependencies": {
     "ometajs": "~3.2.4",
     "xjst": "0.4.13",
-    "mocha-coverjs": "*",
     "mocha": "~1.11.0",
     "chai": "~1.0.3",
-    "coverjs": ">= 0.0.7-alpha",
     "jshint": "~2.1.4",
     "chai-as-promised": "~3.3.1",
     "mocha-as-promised": "~1.4.0",
     "bem-smoke": "~0.3.2",
-    "sinon": "~1.7.3"
+    "sinon": "~1.7.3",
+    "istanbul": "~0.1.44"
   },
   "scripts": {
     "test": "make test",

--- a/test/data/make/project/pages-with-merged/.bem/level.js
+++ b/test/data/make/project/pages-with-merged/.bem/level.js
@@ -1,4 +1,4 @@
-var extend = require(process.env.COVER? 'bem/lib-cov/util' : 'bem/lib/util').extend;
+var extend = require('bem/lib/util').extend;
 
 exports.getTechs = function() {
     return {

--- a/test/tech.js
+++ b/test/tech.js
@@ -264,19 +264,16 @@ describe('tech', function() {
 
 function testBaseTech(techPath, techAlias) {
 
-    var bemLib = process.env.COVER? 'bem/lib-cov/' : 'bem/lib/',
+    var bemLib = 'bem/lib/',
         techName = PATH.basename(techPath),
         absTechPath = require.resolve(PATH.resolve(__dirname, techPath)),
-        relTechPath = techPath + '.js',
-        re = process.env.COVER? /^\.\.\/lib-cov\// : /^\.\.\/lib\//;
+        relTechPath = techPath + '.js';
 
     // NOTE: techPath will be always in unix format
-    if(re.test(techPath)) {
-        relTechPath = relTechPath.replace(re, bemLib);
+    relTechPath = relTechPath.replace(/^\.\.\/lib\//, bemLib);
 
-        // default tech identified by '' relative path
-        if(techName === 'tech') relTechPath = '';
-    }
+    // default tech identified by '' relative path
+    if(techName === 'tech') relTechPath = '';
 
     techAlias = techAlias || techName;
 
@@ -398,7 +395,7 @@ function testBaseTech(techPath, techAlias) {
 
 describe('tech modules', function() {
 
-    var lib = process.env.COVER? '../lib-cov/' : '../lib/';
+    var lib = '../lib/';
 
     testBaseTech(lib + 'techs/js');
     testBaseTech(lib + 'techs/css');

--- a/test/util.js
+++ b/test/util.js
@@ -19,7 +19,7 @@ var assert = require('chai').assert,
 
 describe('util', function() {
 
-    var bemLib = process.env.COVER? 'bem/lib-cov/' : 'bem/lib/';
+    var bemLib = 'bem/lib/';
 
     describe('getBemTechPath()', function() {
 


### PR DESCRIPTION
No `lib-cov` directory is created, so there is no need to check for `process.env.COVER` anymore. Tests can be run with coverage reporting using `npm test --coverage`
