### PR TITLE
Introduce tech.getDefaultMakeCommand()

### DIFF
--- a/lib/nodes/bundle.js
+++ b/lib/nodes/bundle.js
@@ -74,8 +74,11 @@ registry.decl(BundleNodeName, BlockNode, /** @lends BundleNode.prototype */ {
 
         var f = 'create-' + tech + '-node';
 
-        if (typeof this[f] === 'function') LOGGER.fdebug('Using %s() to create node for tech %s', f, tech);
-        else f = 'createDefaultTechNode';
+        if (typeof this[f] === 'function') {
+            LOGGER.fdebug('Using %s() to create node for tech %s', f, tech);
+        } else {
+            f = 'createDefaultTechNode';
+        }
 
         return this[f].apply(this, arguments);
 

--- a/lib/nodes/bundle.js
+++ b/lib/nodes/bundle.js
@@ -74,31 +74,8 @@ registry.decl(BundleNodeName, BlockNode, /** @lends BundleNode.prototype */ {
 
         var f = 'create-' + tech + '-node';
 
-        if (typeof this[f] !== 'function') {
-            f = 'createDefaultTechNode';
-
-            var defaultCmd = this.level.getTech(tech).getDefaultMakeCommand();
-            if (defaultCmd) {
-                switch (defaultCmd) {
-                    case 'create':
-                        f = 'setBemCreateNode';
-                        break;
-
-                    case 'build':
-                        f = 'createDefaultTechNode';
-                        break;
-
-                    default:
-                        throw new Error(UTIL.format(
-                            'Tech %s on the level %s returned unknown command `%s` in the getDefaultTechCommand() method',
-                            tech,
-                            this.level.dir,
-                            defaultCmd));
-                }
-            }
-        }
-
-        LOGGER.fdebug('Using %s() to create node for tech %s', f, tech);
+        if (typeof this[f] === 'function') LOGGER.fdebug('Using %s() to create node for tech %s', f, tech);
+        else f = 'createDefaultTechNode';
 
         return this[f].apply(this, arguments);
 
@@ -321,11 +298,21 @@ registry.decl(BundleNodeName, BlockNode, /** @lends BundleNode.prototype */ {
 
     createDefaultTechNode: function(tech, bundleNode, magicNode) {
 
-        return this.setBemBuildNode(
-            tech,
-            this.getBundlePath('deps.js'),
-            bundleNode,
-            magicNode);
+        var defaultCmd = this.level.getTech(tech).getDefaultMakeCommand();
+
+        if (defaultCmd === 'build') {
+            LOGGER.fdebug('Using setBemBuildNode() to create node for tech %s', tech);
+            return this.setBemBuildNode(tech, this.getBundlePath('deps.js'), bundleNode, magicNode);
+        } else if (defaultCmd === 'create') {
+            LOGGER.fdebug('Using setBemCreateNode() to create node for tech %s', tech);
+            return this.setBemCreateNode(tech, bundleNode, magicNode);
+        } else {
+            throw new Error(UTIL.format(
+                'Tech %s on the level %s returned unknown command `%s` in the getDefaultTechCommand() method',
+                tech,
+                this.level.dir,
+                defaultCmd));
+        }
     },
 
     'create-bemjson.js-node': function(tech, bundleNode, magicNode) {

--- a/lib/nodes/bundle.js
+++ b/lib/nodes/bundle.js
@@ -3,6 +3,7 @@
 var Q = require('q'),
     U = require('../util'),
     PATH = require('../path'),
+    UTIL = require('util'),
     FS = require('fs'),
 
     BlockNode = require('./block').BlockNodeName,
@@ -72,7 +73,30 @@ registry.decl(BundleNodeName, BlockNode, /** @lends BundleNode.prototype */ {
     createTechNode: function(tech, bundleNode, magicNode) {
 
         var f = 'create-' + tech + '-node';
-        f = typeof this[f] === 'function'? f : 'createDefaultTechNode';
+
+        if (typeof this[f] !== 'function') {
+            f = 'createDefaultTechNode';
+
+            var defaultCmd = this.level.getTech(tech).getDefaultMakeCommand();
+            if (defaultCmd) {
+                switch (defaultCmd) {
+                    case 'create':
+                        f = 'setBemCreateNode';
+                        break;
+
+                    case 'build':
+                        f = 'createDefaultTechNode';
+                        break;
+
+                    default:
+                        throw new Error(UTIL.format(
+                            'Tech %s on the level %s returned unknown command `%s` in the getDefaultTechCommand() method',
+                            tech,
+                            this.level.dir,
+                            defaultCmd));
+                }
+            }
+        }
 
         LOGGER.fdebug('Using %s() to create node for tech %s', f, tech);
 
@@ -328,24 +352,6 @@ registry.decl(BundleNodeName, BlockNode, /** @lends BundleNode.prototype */ {
     },
 
     'create-html-node': function(tech, bundleNode, magicNode) {
-
-        return this.setBemCreateNode(
-            tech,
-            bundleNode,
-            magicNode);
-
-    },
-
-    'create-min.css-node': function(tech, bundleNode, magicNode) {
-
-        return this.setBemCreateNode(
-            tech,
-            bundleNode,
-            magicNode);
-
-    },
-
-    'create-min.js-node': function(tech, bundleNode, magicNode) {
 
         return this.setBemCreateNode(
             tech,

--- a/lib/tech/v1.js
+++ b/lib/tech/v1.js
@@ -678,7 +678,7 @@ var Q = require('q'),
          * will be used when BundleNode has no `create-<tech>-node()` method defined.
          */
         getDefaultMakeCommand: function() {
-            // stub.
+            return 'build';
         }
 
     }, {

--- a/lib/tech/v1.js
+++ b/lib/tech/v1.js
@@ -671,6 +671,14 @@ var Q = require('q'),
          */
         preferFork: function() {
             // Stub.
+        },
+
+        /**
+         * Return bem command ('build' or 'create') to use by default when <bem make> invokes the tech. This command
+         * will be used when BundleNode has no `create-<tech>-node()` method defined.
+         */
+        getDefaultMakeCommand: function() {
+            // stub.
         }
 
     }, {

--- a/lib/tech/v2.js
+++ b/lib/tech/v2.js
@@ -702,7 +702,7 @@ var Q = require('q'),
          * will be used when BundleNode has no `create-<tech>-node()` method defined.
          */
         getDefaultMakeCommand: function() {
-            // stub.
+            return 'build';
         }
 
     }, {

--- a/lib/tech/v2.js
+++ b/lib/tech/v2.js
@@ -695,6 +695,14 @@ var Q = require('q'),
          */
         preferFork: function() {
             // Stub.
+        },
+
+        /**
+         * Return bem command ('build' or 'create') to use by default when <bem make> invokes the tech. This command
+         * will be used when BundleNode has no `create-<tech>-node()` method defined.
+         */
+        getDefaultMakeCommand: function() {
+            // stub.
         }
 
     }, {

--- a/lib/techs/v2/min.js
+++ b/lib/techs/v2/min.js
@@ -71,5 +71,9 @@ exports.techMixin = {
 
     preferFork: function() {
         return true;
+    },
+
+    getDefaultMakeCommand: function() {
+        return 'create';
     }
 };

--- a/test/data/make/project/.bem/make.js
+++ b/test/data/make/project/.bem/make.js
@@ -96,23 +96,6 @@ module.exports = function(make) {
                 // add i18n techs
                 return arr.concat(['i18n', 'i18n.js', 'min.ie.css', 'min.i18n.js']);
 
-            },
-
-
-            'create-min.ie.css-node': function(tech, bundleNode, magicNode) {
-
-                return this.setBemCreateNode(
-                    tech,
-                    bundleNode,
-                    magicNode);
-            },
-
-            'create-min.i18n.js-node': function(tech, bundleNode, magicNode) {
-
-                return this.setBemCreateNode(
-                    tech,
-                    bundleNode,
-                    magicNode);
             }
 
         });


### PR DESCRIPTION
Introduce `tech.getDefaultMakeCommand()` which depending on the returned value (`'build'` / `'create'`) tells bem make to use `bem build` or `bem create` when `BundleNode` has no specific `create-<tech>-node()` method defined (close BEM-1300)
