### PR TITLE
make test-setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,3 @@ matrix:
     - node_js: "0.11"
 
 before_install: "npm -g install npm"
-before_script: "ln -s .. node_modules/bem && ls -la node_modules && git submodule init && git submodule update"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -17,8 +17,13 @@ clean:
 jshint:
 	$(JSHINT) lib test
 
+.PHONY: test-setup
+test-setup:
+	@test -e node_modules/bem || ln -s .. node_modules/bem
+	@git submodule update --init
+
 .PHONY: test
-test: jshint
+test: test-setup jshint
 	$(MOCHA)
 
 .PHONY: lib-cov


### PR DESCRIPTION
`make test-setup` command to call `git submodule update --init` and `ln -s .. node_modules/bem`
it should be there because tests fails on pure `npm test` after installation
fixes #477
