### PR TITLE
Add output argument to getBuildPaths call

### DIFF
--- a/lib/tech/v2.js
+++ b/lib/tech/v2.js
@@ -192,7 +192,7 @@ var Q = require('q'),
         readAllContent: function(prefix) {
             var _this = this,
                 res = {};
-            
+
             return Q
                 .all(this.getCreateSuffixes().map(function(suffix) {
                     return _this.readContent(_this.getPath(prefix, suffix), suffix)
@@ -277,7 +277,7 @@ var Q = require('q'),
         getBuildResults: function(decl, levels, output, opts) {
             var _this = this,
                 res = {},
-                files = this.getBuildPaths(decl, levels);
+                files = this.getBuildPaths(decl, levels, output);
 
             return files.then(function(files) {
                 return Q.all(_this.getBuildSuffixes()


### PR DESCRIPTION
Вот здесь https://github.com/bem/bem-techs-core/blob/master/techs/i18n.browser.js.js#L52 используется `output`, который туда не попадает. Я не нашел, как его пробросить иначе, чем в базовой технологии.

// cc @arikon @SevInf 
