### PR TITLE
Save build cache data only on successful build

### DIFF
--- a/lib/tech/v2.js
+++ b/lib/tech/v2.js
@@ -288,12 +288,13 @@ var Q = require('q'),
                         return _this.validate(file, filteredFiles, opts)
                             .then(function(valid) {
                                 LOGGER.fverbose('file %s is %s', file, valid?'valid':'not valid');
+
                                 if (!valid) {
-                                    _this.saveLastUsedData(file, {buildFiles: filteredFiles});
 
                                     return _this.getBuildResult(filteredFiles, destSuffix, output, opts)
                                         .then(function(r) {
                                             res[destSuffix] = r;
+                                            return _this.saveLastUsedData(file, {buildFiles: filteredFiles});
                                         });
                                 }
                             });


### PR DESCRIPTION
If `getBuildResult` fails, `getBuildResults` was still saving source files timestamps. So, if malformed source file was not changed before next build, `getBuildResult` won't be called second time and build error will not be reproduced.

To reproduce:
1.  Check out `bemhtml` tech from bem/bem-bl#439
2. Build some valid `bemhtml` with it.
3. Change `bemhtml` to be invalid.
4. Build project again. It will fail with error.
5. Build project again. Build will not fail second time.

@arikon @scf2k 
