### PR TITLE
Fix paths in cases of building separate targets for Windows OS

### DIFF
--- a/lib/make.js
+++ b/lib/make.js
@@ -19,6 +19,8 @@ exports.APW = INHERIT(APW, {
     findAndProcess: function(targets) {
         if (!Array.isArray(targets)) targets = [targets];
 
+        targets = replaceSlashes(targets);
+
         // Strip trailing slashes from target names
         // See https://github.com/bem/bem-tools/issues/252
         var re = new RegExp(PATH.dirSep + '$');
@@ -142,4 +144,10 @@ function evalConfig(content, path) {
     LOGGER.fsilly("File '%s' evaled", path);
     /* jshint +W109 */
 
+}
+
+function replaceSlashes(targets) {
+    return require('path').sep === '\/' ? targets : targets.map(function (target) {
+        return target.replace(/\//g, '\\');
+    });
 }


### PR DESCRIPTION
These changes give the ability to write paths to targets while using `Windows OS` both with `Linux` and `Windows` slashes.

For example,

``` bash
bem make PATH/TO/TARGET
```

and

``` bash
bem make PATH\TO\TARGET
```

(The first variant fails without these changes)
